### PR TITLE
Add custom OpenAI configuration option

### DIFF
--- a/sample.config.toml
+++ b/sample.config.toml
@@ -4,6 +4,7 @@ SIMILARITY_MEASURE = "cosine" # "cosine" or "dot"
 
 [API_KEYS]
 OPENAI = "" # OpenAI API key - sk-1234567890abcdef1234567890abcdef
+OPENAI_BASE_URL = "https://api.openai.com/v1" # OpenAI API base URL
 GROQ = "" # Groq API key - gsk_1234567890abcdef1234567890abcdef
 
 [API_ENDPOINTS]

--- a/sample.config.toml
+++ b/sample.config.toml
@@ -5,6 +5,7 @@ SIMILARITY_MEASURE = "cosine" # "cosine" or "dot"
 [API_KEYS]
 OPENAI = "" # OpenAI API key - sk-1234567890abcdef1234567890abcdef
 OPENAI_BASE_URL = "https://api.openai.com/v1" # OpenAI API base URL
+OPENAI_CUSTOM_CHAT_MODEL = "" # OpenAI custom chat model ID - gpt-3.5-turbo-1106
 GROQ = "" # Groq API key - gsk_1234567890abcdef1234567890abcdef
 
 [API_ENDPOINTS]

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ interface Config {
   API_KEYS: {
     OPENAI: string;
     OPENAI_BASE_URL: string;
+    OPENAI_CUSTOM_CHAT_MODEL: string;
     GROQ: string;
   };
   API_ENDPOINTS: {
@@ -38,6 +39,9 @@ export const getOpenaiApiKey = () => loadConfig().API_KEYS.OPENAI;
 
 export const getOpenaiBaseUrl = () =>
   loadConfig().API_KEYS.OPENAI_BASE_URL || 'https://api.openai.com/v1';
+
+export const getOpenaiCustomChatModel = () =>
+  loadConfig().API_KEYS.OPENAI_CUSTOM_CHAT_MODEL;
 
 export const getGroqApiKey = () => loadConfig().API_KEYS.GROQ;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ interface Config {
   };
   API_KEYS: {
     OPENAI: string;
+    OPENAI_BASE_URL: string;
     GROQ: string;
   };
   API_ENDPOINTS: {
@@ -34,6 +35,9 @@ export const getSimilarityMeasure = () =>
   loadConfig().GENERAL.SIMILARITY_MEASURE;
 
 export const getOpenaiApiKey = () => loadConfig().API_KEYS.OPENAI;
+
+export const getOpenaiBaseUrl = () =>
+  loadConfig().API_KEYS.OPENAI_BASE_URL || 'https://api.openai.com/v1';
 
 export const getGroqApiKey = () => loadConfig().API_KEYS.GROQ;
 

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -6,12 +6,14 @@ import {
   getOllamaApiEndpoint,
   getOpenaiApiKey,
   getOpenaiBaseUrl,
+  getOpenaiCustomChatModel,
 } from '../config';
 import logger from '../utils/logger';
 
 export const getAvailableProviders = async () => {
   const openAIApiKey = getOpenaiApiKey();
   const openAIBaseUrl = getOpenaiBaseUrl();
+  const openAICustomChatModel = getOpenaiCustomChatModel();
   const groqApiKey = getGroqApiKey();
   const ollamaEndpoint = getOllamaApiEndpoint();
 
@@ -50,6 +52,20 @@ export const getAvailableProviders = async () => {
             baseURL: openAIBaseUrl,
           },
         ),
+        ...(openAICustomChatModel.length > 0
+          ? {
+              openAICustomChatModel: new ChatOpenAI(
+                {
+                  openAIApiKey,
+                  modelName: openAICustomChatModel,
+                  temperature: 0.7,
+                },
+                {
+                  baseURL: openAIBaseUrl,
+                },
+              ),
+            }
+          : {}),
         embeddings: new OpenAIEmbeddings(
           {
             openAIApiKey,

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -5,11 +5,13 @@ import {
   getGroqApiKey,
   getOllamaApiEndpoint,
   getOpenaiApiKey,
+  getOpenaiBaseUrl,
 } from '../config';
 import logger from '../utils/logger';
 
 export const getAvailableProviders = async () => {
   const openAIApiKey = getOpenaiApiKey();
+  const openAIBaseUrl = getOpenaiBaseUrl();
   const groqApiKey = getGroqApiKey();
   const ollamaEndpoint = getOllamaApiEndpoint();
 
@@ -18,25 +20,45 @@ export const getAvailableProviders = async () => {
   if (openAIApiKey) {
     try {
       models['openai'] = {
-        'GPT-3.5 turbo': new ChatOpenAI({
-          openAIApiKey,
-          modelName: 'gpt-3.5-turbo',
-          temperature: 0.7,
-        }),
-        'GPT-4': new ChatOpenAI({
-          openAIApiKey,
-          modelName: 'gpt-4',
-          temperature: 0.7,
-        }),
-        'GPT-4 turbo': new ChatOpenAI({
-          openAIApiKey,
-          modelName: 'gpt-4-turbo',
-          temperature: 0.7,
-        }),
-        embeddings: new OpenAIEmbeddings({
-          openAIApiKey,
-          modelName: 'text-embedding-3-large',
-        }),
+        'GPT-3.5 turbo': new ChatOpenAI(
+          {
+            openAIApiKey,
+            modelName: 'gpt-3.5-turbo',
+            temperature: 0.7,
+          },
+          {
+            baseURL: openAIBaseUrl,
+          },
+        ),
+        'GPT-4': new ChatOpenAI(
+          {
+            openAIApiKey,
+            modelName: 'gpt-4',
+            temperature: 0.7,
+          },
+          {
+            baseURL: openAIBaseUrl,
+          },
+        ),
+        'GPT-4 turbo': new ChatOpenAI(
+          {
+            openAIApiKey,
+            modelName: 'gpt-4-turbo',
+            temperature: 0.7,
+          },
+          {
+            baseURL: openAIBaseUrl,
+          },
+        ),
+        embeddings: new OpenAIEmbeddings(
+          {
+            openAIApiKey,
+            modelName: 'text-embedding-3-large',
+          },
+          {
+            baseURL: openAIBaseUrl,
+          },
+        ),
       };
     } catch (err) {
       logger.error(`Error loading OpenAI models: ${err}`);
@@ -86,10 +108,15 @@ export const getAvailableProviders = async () => {
             baseURL: 'https://api.groq.com/openai/v1',
           },
         ),
-        embeddings: new OpenAIEmbeddings({
-          openAIApiKey: openAIApiKey,
-          modelName: 'text-embedding-3-large',
-        }),
+        embeddings: new OpenAIEmbeddings(
+          {
+            openAIApiKey: openAIApiKey,
+            modelName: 'text-embedding-3-large',
+          },
+          {
+            baseURL: openAIBaseUrl,
+          },
+        ),
       };
     } catch (err) {
       logger.error(`Error loading Groq models: ${err}`);

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -4,6 +4,7 @@ import {
   getGroqApiKey,
   getOllamaApiEndpoint,
   getOpenaiApiKey,
+  getOpenaiBaseUrl,
   updateConfig,
 } from '../config';
 
@@ -25,6 +26,7 @@ router.get('/', async (_, res) => {
   }
 
   config['openaiApiKey'] = getOpenaiApiKey();
+  config['openaiBaseUrl'] = getOpenaiBaseUrl();
   config['ollamaApiUrl'] = getOllamaApiEndpoint();
   config['groqApiKey'] = getGroqApiKey();
 
@@ -37,6 +39,7 @@ router.post('/', async (req, res) => {
   const updatedConfig = {
     API_KEYS: {
       OPENAI: config.openaiApiKey,
+      OPENAI_BASE_URL: config.openaiBaseUrl,
       GROQ: config.groqApiKey,
     },
     API_ENDPOINTS: {

--- a/src/routes/config.ts
+++ b/src/routes/config.ts
@@ -5,6 +5,7 @@ import {
   getOllamaApiEndpoint,
   getOpenaiApiKey,
   getOpenaiBaseUrl,
+  getOpenaiCustomChatModel,
   updateConfig,
 } from '../config';
 
@@ -27,6 +28,7 @@ router.get('/', async (_, res) => {
 
   config['openaiApiKey'] = getOpenaiApiKey();
   config['openaiBaseUrl'] = getOpenaiBaseUrl();
+  config['openaiCustomChatModel'] = getOpenaiCustomChatModel();
   config['ollamaApiUrl'] = getOllamaApiEndpoint();
   config['groqApiKey'] = getGroqApiKey();
 
@@ -40,6 +42,7 @@ router.post('/', async (req, res) => {
     API_KEYS: {
       OPENAI: config.openaiApiKey,
       OPENAI_BASE_URL: config.openaiBaseUrl,
+      OPENAI_CUSTOM_CHAT_MODEL: config.openaiCustomChatModel,
       GROQ: config.groqApiKey,
     },
     API_ENDPOINTS: {

--- a/ui/components/SettingsDialog.tsx
+++ b/ui/components/SettingsDialog.tsx
@@ -7,6 +7,7 @@ interface SettingsType {
     [key: string]: string[];
   };
   openaiApiKey: string;
+  openaiBaseUrl: string;
   groqApiKey: string;
   ollamaApiUrl: string;
 }
@@ -178,6 +179,21 @@ const SettingsDialog = ({
                           setConfig({
                             ...config,
                             openaiApiKey: e.target.value,
+                          })
+                        }
+                        className="bg-[#111111] px-3 py-2 flex items-center overflow-hidden border border-[#1C1C1C] text-white rounded-lg text-sm"
+                      />
+                    </div>
+                    <div className="flex flex-col space-y-1">
+                      <p className="text-white/70 text-sm">OpenAI Base URL</p>
+                      <input
+                        type="text"
+                        placeholder="OpenAI Base URL"
+                        defaultValue={config.openaiBaseUrl}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            openaiBaseUrl: e.target.value,
                           })
                         }
                         className="bg-[#111111] px-3 py-2 flex items-center overflow-hidden border border-[#1C1C1C] text-white rounded-lg text-sm"


### PR DESCRIPTION
- `OPENAI_BASE_URL`: The base URL for the OpenAI API, e.g., https://api.example.com/v1
- `OPENAI_CUSTOM_CHAT_MODEL`: Enables support for custom chat models, which may require function calling

These settings enable compatibility with custom relay services like OpenRouter or self-deployed instances of OneAPI.