### PR TITLE
chore: change searxng service export port

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: searxng.dockerfile
     expose:
-      - 4000
+      - 8080
     ports:
       - 4000:8080
     networks:


### PR DESCRIPTION
expose defines the (incoming) port or a range of ports that Compose exposes from the container. 

[expose](https://docs.docker.com/compose/compose-file/05-services/#expose)