### PR TITLE
build(app): optimize app docker image size

### DIFF
--- a/app.dockerfile
+++ b/app.dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:alpine as builder
 
 ARG NEXT_PUBLIC_WS_URL
 ARG NEXT_PUBLIC_API_URL
@@ -12,4 +12,6 @@ COPY ui /home/perplexica/
 RUN yarn install
 RUN yarn build
 
-CMD ["yarn", "start"]
+FROM nginx:stable-alpine-slim
+
+COPY --from=builder /home/perplexica/out /usr/share/nginx/html

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
     depends_on:
       - perplexica-backend
     ports:
-      - 3000:3000
+      - 3000:80
     networks:
       - perplexica-network
 

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
export app static pages and deploy with Nginx image, instead of host `next start` service