### PR TITLE
Add basic searxng-limiter.toml configuration file

### DIFF
--- a/searxng-limiter.toml
+++ b/searxng-limiter.toml
@@ -1,0 +1,3 @@
+[botdetection.ip_limit]
+
+link_token = true

--- a/searxng.dockerfile
+++ b/searxng.dockerfile
@@ -1,3 +1,4 @@
 FROM searxng/searxng
 
 COPY searxng-settings.yml /etc/searxng/settings.yml
+COPY searxng-limiter.toml /etc/searxng/limiter.toml


### PR DESCRIPTION
Added a basic limiter.toml file to address these Searxng warnings:
```bash
2024-05-08 11:44:35,153 WARNING:searx.botdetection.config: missing config file: /etc/searxng/limiter.toml
WSGI app 0 (mountpoint='') ready in 1 seconds on interpreter 0xffffa40d9ac0 pid: 17 (default app)
```

