### PR TITLE
Fix: add extra_hosts to docker-compose.yaml to allow connection to ollama

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       - searxng
     ports:
       - 3001:3001
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - perplexica-network
 
@@ -32,6 +34,8 @@ services:
       - perplexica-backend
     ports:
       - 3000:3000
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - perplexica-network
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,8 +34,6 @@ services:
       - perplexica-backend
     ports:
       - 3000:3000
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     networks:
       - perplexica-network
 


### PR DESCRIPTION
This pull request enhances the Docker Compose configuration by adding extra_hosts entries to enable connections to ollama. This change is necessary to facilitate seamless communication between containers and the host system, particularly for the perplexica-backend and perplexica-frontend services.

Fixes #117 