### PR TITLE
feat: Allow direct English input in search box with Chinese IME

### DIFF
--- a/ui/components/EmptyChatMessageInput.tsx
+++ b/ui/components/EmptyChatMessageInput.tsx
@@ -23,7 +23,7 @@ const EmptyChatMessageInput = ({
         setMessage('');
       }}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
+        if (e.key === 'Enter' && !e.shiftKey && e.keyCode != 229) {
           e.preventDefault();
           sendMessage(message);
           setMessage('');

--- a/ui/components/MessageInput.tsx
+++ b/ui/components/MessageInput.tsx
@@ -33,7 +33,7 @@ const MessageInput = ({
         setMessage('');
       }}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' && !e.shiftKey && !loading) {
+        if (e.key === 'Enter' && !e.shiftKey && !loading && e.keyCode != 229) {
           e.preventDefault();
           sendMessage(message);
           setMessage('');


### PR DESCRIPTION
This pull request addresses an issue where, under the use of a Chinese Input Method Editor (IME), entering English text directly into the search box and pressing Enter would mistakenly trigger the search action. This was not the intended behavior; instead, the expectation was for the English word to be inputted directly.

**Problem:**

- When using a Chinese IME, pressing Enter after typing English text in the search box would cause an unwanted search action.
- This disrupted the user experience, particularly for users who frequently switch between English and Chinese input without changing IMEs.

**Solution:**

- The input handling logic has been modified to correctly differentiate between intentional search actions and direct English text input within the Chinese IME context.
- With this fix, users can now input English text directly in the search box and confirm it with Enter, without triggering an unwanted search.