### PR TITLE
feat(settings): support settings on mobile device

### DIFF
--- a/ui/components/EmptyChat.tsx
+++ b/ui/components/EmptyChat.tsx
@@ -1,5 +1,5 @@
 import EmptyChatMessageInput from './EmptyChatMessageInput';
-import ThemeSwitcher from './theme/Switcher';
+import SettingsEntry from './SettingsEntry';
 
 const EmptyChat = ({
   sendMessage,
@@ -12,7 +12,7 @@ const EmptyChat = ({
 }) => {
   return (
     <div className="relative">
-      <ThemeSwitcher size={17} className="absolute top-2 right-0 lg:hidden" />
+      <SettingsEntry className="absolute top-4 right-0 lg:hidden" />
 
       <div className="flex flex-col items-center justify-center min-h-screen max-w-screen-sm mx-auto p-2 space-y-8">
         <h2 className="text-black/70 dark:text-white/70 text-3xl font-medium -mt-8">

--- a/ui/components/Navbar.tsx
+++ b/ui/components/Navbar.tsx
@@ -2,7 +2,7 @@ import { Clock, Edit, Share, Trash } from 'lucide-react';
 import { Message } from './ChatWindow';
 import { useEffect, useState } from 'react';
 import { formatTimeDifference } from '@/lib/utils';
-import ThemeSwitcher from './theme/Switcher';
+import SettingsEntry from './SettingsEntry';
 
 const Navbar = ({ messages }: { messages: Message[] }) => {
   const [title, setTitle] = useState<string>('');
@@ -50,9 +50,11 @@ const Navbar = ({ messages }: { messages: Message[] }) => {
       </div>
       <p className="hidden lg:flex">{title}</p>
 
-      <ThemeSwitcher size={17} className="lg:hidden ml-auto mr-4" />
-
       <div className="flex flex-row items-center space-x-4">
+        <SettingsEntry
+          size={17}
+          className="active:scale-95 transition duration-100 cursor-pointer"
+        />
         <Share
           size={17}
           className="active:scale-95 transition duration-100 cursor-pointer"

--- a/ui/components/SettingsEntry.tsx
+++ b/ui/components/SettingsEntry.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react';
 import { Settings } from 'lucide-react';
+import type { LucideProps } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import SettingsDialog from './SettingsDialog';
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
-
-const SettingsEntry = ({ className }: InputProps) => {
+const SettingsEntry = ({ className, ...restProps }: LucideProps) => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
   return (
     <>
       <Settings
+        {...restProps}
         onClick={() => setIsSettingsOpen(!isSettingsOpen)}
         className={cn('cursor-pointer', className)}
       />

--- a/ui/components/SettingsEntry.tsx
+++ b/ui/components/SettingsEntry.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { Settings } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import SettingsDialog from './SettingsDialog';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const SettingsEntry = ({ className }: InputProps) => {
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+
+  return (
+    <>
+      <Settings
+        onClick={() => setIsSettingsOpen(!isSettingsOpen)}
+        className={cn('cursor-pointer', className)}
+      />
+
+      <SettingsDialog isOpen={isSettingsOpen} setIsOpen={setIsSettingsOpen} />
+    </>
+  );
+};
+
+export default SettingsEntry;

--- a/ui/components/Sidebar.tsx
+++ b/ui/components/Sidebar.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import { BookOpenText, Home, Search, SquarePen, Settings } from 'lucide-react';
+import { BookOpenText, Home, Search, SquarePen } from 'lucide-react';
 import Link from 'next/link';
 import { useSelectedLayoutSegments } from 'next/navigation';
 import React, { useState, type ReactNode } from 'react';
 import Layout from './Layout';
-import SettingsDialog from './SettingsDialog';
-import ThemeSwitcher from './theme/Switcher';
+import SettingsEntry from './SettingsEntry';
 
 const VerticalIconContainer = ({ children }: { children: ReactNode }) => {
   return (
@@ -68,15 +67,7 @@ const Sidebar = ({ children }: { children: React.ReactNode }) => {
             ))}
           </VerticalIconContainer>
 
-          <Settings
-            onClick={() => setIsSettingsOpen(!isSettingsOpen)}
-            className="cursor-pointer"
-          />
-
-          <SettingsDialog
-            isOpen={isSettingsOpen}
-            setIsOpen={setIsSettingsOpen}
-          />
+          <SettingsEntry />
         </div>
       </div>
 


### PR DESCRIPTION
Now there is no setting entry on mobile devices, this PR replaces ThemeSwicher with a setting entry so that all settings, including theme, can be changed on small screens.