### PR TITLE
fix(ui): ui compile fail

### DIFF
--- a/ui/components/EmptyChat.tsx
+++ b/ui/components/EmptyChat.tsx
@@ -1,5 +1,4 @@
 import EmptyChatMessageInput from './EmptyChatMessageInput';
-import ThemeSwitcher from './theme/Switcher';
 
 const EmptyChat = ({
   sendMessage,

--- a/ui/components/EmptyChat.tsx
+++ b/ui/components/EmptyChat.tsx
@@ -12,8 +12,6 @@ const EmptyChat = ({
 }) => {
   return (
     <div className="relative">
-      <ThemeSwitcher size={17} className="absolute top-2 right-0 lg:hidden" />
-
       <div className="flex flex-col items-center justify-center min-h-screen max-w-screen-sm mx-auto p-2 space-y-8">
         <h2 className="text-black/70 dark:text-white/70 text-3xl font-medium -mt-8">
           Research begins here.

--- a/ui/components/MessageBox.tsx
+++ b/ui/components/MessageBox.tsx
@@ -7,7 +7,6 @@ import { cn } from '@/lib/utils';
 import {
   BookCopy,
   Disc3,
-  Share,
   Volume2,
   StopCircle,
   Layers3,

--- a/ui/components/Navbar.tsx
+++ b/ui/components/Navbar.tsx
@@ -50,8 +50,6 @@ const Navbar = ({ messages }: { messages: Message[] }) => {
       </div>
       <p className="hidden lg:flex">{title}</p>
 
-      <ThemeSwitcher size={17} className="lg:hidden ml-auto mr-4" />
-
       <div className="flex flex-row items-center space-x-4">
         <Share
           size={17}

--- a/ui/components/Navbar.tsx
+++ b/ui/components/Navbar.tsx
@@ -2,7 +2,6 @@ import { Clock, Edit, Share, Trash } from 'lucide-react';
 import { Message } from './ChatWindow';
 import { useEffect, useState } from 'react';
 import { formatTimeDifference } from '@/lib/utils';
-import ThemeSwitcher from './theme/Switcher';
 
 const Navbar = ({ messages }: { messages: Message[] }) => {
   const [title, setTitle] = useState<string>('');

--- a/ui/components/SettingsDialog.tsx
+++ b/ui/components/SettingsDialog.tsx
@@ -4,7 +4,6 @@ import { CloudUpload, RefreshCcw, RefreshCw } from 'lucide-react';
 import React, {
   Fragment,
   useEffect,
-  useMemo,
   useState,
   type SelectHTMLAttributes,
 } from 'react';

--- a/ui/components/Sidebar.tsx
+++ b/ui/components/Sidebar.tsx
@@ -7,7 +7,6 @@ import { useSelectedLayoutSegments } from 'next/navigation';
 import React, { useState, type ReactNode } from 'react';
 import Layout from './Layout';
 import SettingsDialog from './SettingsDialog';
-import ThemeSwitcher from './theme/Switcher';
 
 const VerticalIconContainer = ({ children }: { children: ReactNode }) => {
   return (

--- a/ui/components/theme/Switcher.tsx
+++ b/ui/components/theme/Switcher.tsx
@@ -2,7 +2,6 @@
 import { useTheme } from 'next-themes';
 import { SunIcon, MoonIcon, MonitorIcon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
-import { cn } from '@/lib/utils';
 import { Select } from '../SettingsDialog';
 
 type Theme = 'dark' | 'light' | 'system';
@@ -53,7 +52,7 @@ const ThemeSwitcher = ({ className }: { className?: string }) => {
       onChange={(e) => handleThemeSwitch(e.target.value as Theme)}
       options={[
         { value: 'light', label: 'Light' },
-        { value: 'dark', label: 'Dark' }
+        { value: 'dark', label: 'Dark' },
       ]}
     />
   );


### PR DESCRIPTION
This problem is caused by the `ThemeSwitcher` component be refactored with not checked completely.

solution:
remove both of them, a new feature is coming soon -  mobile device support setting NavBar.

