### PR TITLE
fix: ThemeSwitcher needs "size" as argument

### DIFF
--- a/ui/components/theme/Switcher.tsx
+++ b/ui/components/theme/Switcher.tsx
@@ -7,7 +7,7 @@ import { Select } from '../SettingsDialog';
 
 type Theme = 'dark' | 'light' | 'system';
 
-const ThemeSwitcher = ({ className }: { className?: string }) => {
+const ThemeSwitcher = ({ className, size }: { className?: string, size?: number }) => {
   const [mounted, setMounted] = useState(false);
 
   const { theme, setTheme } = useTheme();


### PR DESCRIPTION
#212 

ThemeSwitcher needs 'size' as input argument, otherwise the docker-compose build fails