### PR TITLE
perf(backend): only read similarityMeasure once

### DIFF
--- a/src/utils/computeSimilarity.ts
+++ b/src/utils/computeSimilarity.ts
@@ -2,9 +2,9 @@ import dot from 'compute-dot';
 import cosineSimilarity from 'compute-cosine-similarity';
 import { getSimilarityMeasure } from '../config';
 
-const computeSimilarity = (x: number[], y: number[]): number => {
-  const similarityMeasure = getSimilarityMeasure();
+const similarityMeasure = getSimilarityMeasure();
 
+const computeSimilarity = (x: number[], y: number[]): number => {
   if (similarityMeasure === 'cosine') {
     return cosineSimilarity(x, y);
   } else if (similarityMeasure === 'dot') {


### PR DESCRIPTION
Hi, really cool project. I was just perusing the files when I noticed that this `getSimilarityMeasure` function is reading from the toml file on each invocation.
I would not imagine that this needs to be something that is modifiable at runtime, so I made it only ever check the file once on startup, and each successive invocation re-uses the cached value.

Totally minor performance optimization 
