### PR TITLE
Use userSessionId for chat history

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -16,4 +16,5 @@ export const chats = sqliteTable('chats', {
   title: text('title').notNull(),
   createdAt: text('createdAt').notNull(),
   focusMode: text('focusMode').notNull(),
+  userSessionId: text('userSessionId'),
 });

--- a/src/routes/chats.ts
+++ b/src/routes/chats.ts
@@ -6,13 +6,20 @@ import { chats, messages } from '../db/schema';
 
 const router = express.Router();
 
-router.get('/', async (_, res) => {
+router.get('/', async (req, res) => {
   try {
-    let chats = await db.query.chats.findMany();
+    let userSessionId = req.headers['user-session-id'] ? req.headers['user-session-id'].toString() : '';
+    if (userSessionId == '') {
+      return res.status(200).json({ chats: {}});
+    }
+    
+    let chatRecords = await db.query.chats.findMany({
+      where: eq(chats.userSessionId, userSessionId),
+    });
 
-    chats = chats.reverse();
+    chatRecords = chatRecords.reverse();
 
-    return res.status(200).json({ chats: chats });
+    return res.status(200).json({ chats: chatRecords });
   } catch (err) {
     res.status(500).json({ message: 'An error has occurred.' });
     logger.error(`Error in getting chats: ${err.message}`);

--- a/src/websocket/messageHandler.ts
+++ b/src/websocket/messageHandler.ts
@@ -18,6 +18,7 @@ type Message = {
   messageId: string;
   chatId: string;
   content: string;
+  userSessionId: string;
 };
 
 type WSMessage = {
@@ -154,6 +155,7 @@ export const handleMessage = async (
               title: parsedMessage.content,
               createdAt: new Date().toString(),
               focusMode: parsedWSMessage.focusMode,
+              userSessionId: parsedMessage.userSessionId,
             })
             .execute();
         }

--- a/ui/app/library/page.tsx
+++ b/ui/app/library/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import crypto from 'crypto';
 import DeleteChat from '@/components/DeleteChat';
 import { formatTimeDifference } from '@/lib/utils';
 import { BookOpenText, ClockIcon, Delete, ScanEye } from 'lucide-react';
@@ -21,10 +22,17 @@ const Page = () => {
     const fetchChats = async () => {
       setLoading(true);
 
+      let userSessionId = localStorage.getItem('userSessionId');
+      if (!userSessionId) {
+        userSessionId = crypto.randomBytes(20).toString('hex');
+        localStorage.setItem('userSessionId', userSessionId)
+      }
+
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/chats`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
+          'user-session-id': userSessionId!,
         },
       });
 

--- a/ui/components/ChatWindow.tsx
+++ b/ui/components/ChatWindow.tsx
@@ -38,6 +38,12 @@ const useSocket = (
           'embeddingModelProvider',
         );
 
+        let userSessionId = localStorage.getItem('userSessionId');
+        if (!userSessionId) {
+          userSessionId = crypto.randomBytes(20).toString('hex');
+          localStorage.setItem('userSessionId', userSessionId!)
+        }
+
         if (
           !chatModel ||
           !chatModelProvider ||
@@ -324,6 +330,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
     let added = false;
 
     const messageId = crypto.randomBytes(7).toString('hex');
+    let userSessionId = localStorage.getItem('userSessionId');
 
     ws?.send(
       JSON.stringify({
@@ -331,6 +338,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
         message: {
           chatId: chatId!,
           content: message,
+          userSessionId: userSessionId,
         },
         focusMode: focusMode,
         history: [...chatHistory, ['human', message]],


### PR DESCRIPTION
Currently, all chat history (library) is global for all users. This PR separates them with `userSessionId` so the history (library) appears within the user sessions. 

High-level logics:
 - Add a new column `userSessionId` in the chats table to indicate the chat owner.  
 - In the UI, ChatWindows, `userSessionId` is created or looked up from the localstroage.
   - Send `userSessionId` to the WebSocket so that the chat record is created along with the `userSessionId`. 
 - In the UI, Library page, `userSessionId` is created or looked up from the localstroage.
   - Send `userSessionId` to api/chats in the header to get the chat history
 - In the backend, chats API picks up the `userSessionId` and queries DB only for chats belonging to `userSessionId`. 
