### PR TITLE
perf: Optimize document filtering and sorting for performance

### DIFF
--- a/src/agents/redditSearchAgent.ts
+++ b/src/agents/redditSearchAgent.ts
@@ -52,8 +52,8 @@ const basicRedditSearchResponsePrompt = `
     Place these citations at the end of that particular sentence. You can cite the same sentence multiple times if it is relevant to the user's query like [number1][number2].
     However you do not need to cite it using the same number. You can use different numbers to cite the same sentence multiple times. The number refers to the number of the search result (passed in the context) used to generate that part of the answer.
 
-    Anything inside the following \`context\` HTML block provided below is for your knowledge returned by Reddit and is not shared by the user. You have to answer question on the basis of it and cite the relevant information from it but you do not have to 
-    talk about the context in your response. 
+    Anything inside the following \`context\` HTML block provided below is for your knowledge returned by Reddit and is not shared by the user. You have to answer question on the basis of it and cite the relevant information from it but you do not have to
+    talk about the context in your response.
 
     <context>
     {context}
@@ -177,9 +177,9 @@ const createBasicRedditSearchAnsweringChain = (
     });
 
     const sortedDocs = similarity
+      .filter((sim) => sim.similarity > 0.3)
       .sort((a, b) => b.similarity - a.similarity)
       .slice(0, 15)
-      .filter((sim) => sim.similarity > 0.3)
       .map((sim) => docsWithContent[sim.index]);
 
     return sortedDocs;

--- a/src/agents/webSearchAgent.ts
+++ b/src/agents/webSearchAgent.ts
@@ -52,8 +52,8 @@ const basicWebSearchResponsePrompt = `
     Place these citations at the end of that particular sentence. You can cite the same sentence multiple times if it is relevant to the user's query like [number1][number2].
     However you do not need to cite it using the same number. You can use different numbers to cite the same sentence multiple times. The number refers to the number of the search result (passed in the context) used to generate that part of the answer.
 
-    Anything inside the following \`context\` HTML block provided below is for your knowledge returned by the search engine and is not shared by the user. You have to answer question on the basis of it and cite the relevant information from it but you do not have to 
-    talk about the context in your response. 
+    Anything inside the following \`context\` HTML block provided below is for your knowledge returned by the search engine and is not shared by the user. You have to answer question on the basis of it and cite the relevant information from it but you do not have to
+    talk about the context in your response.
 
     <context>
     {context}
@@ -175,8 +175,8 @@ const createBasicWebSearchAnsweringChain = (
     });
 
     const sortedDocs = similarity
-      .sort((a, b) => b.similarity - a.similarity)
       .filter((sim) => sim.similarity > 0.5)
+      .sort((a, b) => b.similarity - a.similarity)
       .slice(0, 15)
       .map((sim) => docsWithContent[sim.index]);
 

--- a/src/agents/youtubeSearchAgent.ts
+++ b/src/agents/youtubeSearchAgent.ts
@@ -52,8 +52,8 @@ const basicYoutubeSearchResponsePrompt = `
     Place these citations at the end of that particular sentence. You can cite the same sentence multiple times if it is relevant to the user's query like [number1][number2].
     However you do not need to cite it using the same number. You can use different numbers to cite the same sentence multiple times. The number refers to the number of the search result (passed in the context) used to generate that part of the answer.
 
-    Anything inside the following \`context\` HTML block provided below is for your knowledge returned by Youtube and is not shared by the user. You have to answer question on the basis of it and cite the relevant information from it but you do not have to 
-    talk about the context in your response. 
+    Anything inside the following \`context\` HTML block provided below is for your knowledge returned by Youtube and is not shared by the user. You have to answer question on the basis of it and cite the relevant information from it but you do not have to
+    talk about the context in your response.
 
     <context>
     {context}
@@ -177,9 +177,9 @@ const createBasicYoutubeSearchAnsweringChain = (
     });
 
     const sortedDocs = similarity
+      .filter((sim) => sim.similarity > 0.3)
       .sort((a, b) => b.similarity - a.similarity)
       .slice(0, 15)
-      .filter((sim) => sim.similarity > 0.3)
       .map((sim) => docsWithContent[sim.index]);
 
     return sortedDocs;


### PR DESCRIPTION
Switched the order of filter and sort operations to improve efficiency. By filtering out documents with a similarity score lower than 0.3 before sorting, we reduce the workload during the sorting process. This should make the document retrieval quicker and reduce the overall computational cost.