### PR TITLE
Add Missing Dependency @langchain/google-genai Version ^0.0.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@iarna/toml": "^2.2.5",
     "@langchain/anthropic": "^0.2.3",
     "@langchain/community": "^0.2.16",
+    "@langchain/google-genai": "^0.0.23",
     "@langchain/openai": "^0.0.25",
     "@xenova/transformers": "^2.17.1",
     "axios": "^1.6.8",


### PR DESCRIPTION


This pull request adds the previously omitted dependency for `@langchain/google-genai` with version **^0.0.23** to the `package.json` file. 

### Key Changes
- **Dependency Addition**: 
  - Added `@langchain/google-genai` to the `package.json` to ensure that the application has the necessary library for the recently integrated models.

### Context
In the previous pull request (#284), which integrated the Gemini 1.0 Pro Chat Model and Google Embedding -001 Model, I inadvertently forgot to include this essential dependency. Adding it now will ensure that the application functions correctly with the new models.

