### PR TITLE
Do not kill entire chat window when websocket closes.

### DIFF
--- a/ui/components/ChatWindow.tsx
+++ b/ui/components/ChatWindow.tsx
@@ -194,7 +194,7 @@ const useSocket = (
 
         ws.onclose = () => {
           clearTimeout(timeoutId);
-          setError(true);
+          setWs(null);
           console.log('[DEBUG] closed');
         };
 

--- a/ui/components/ChatWindow.tsx
+++ b/ui/components/ChatWindow.tsx
@@ -25,6 +25,7 @@ const useSocket = (
   url: string,
   setIsWSReady: (ready: boolean) => void,
   setError: (error: boolean) => void,
+  hasError: boolean
 ) => {
   const [ws, setWs] = useState<WebSocket | null>(null);
 
@@ -194,7 +195,9 @@ const useSocket = (
 
         ws.onclose = () => {
           clearTimeout(timeoutId);
-          setWs(null);
+          if (!hasError) {
+            setWs(null); // forces websocket to reopen when needed.
+          }
           console.log('[DEBUG] closed');
         };
 
@@ -285,6 +288,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
     process.env.NEXT_PUBLIC_WS_URL!,
     setIsWSReady,
     setHasError,
+    hasError
   );
 
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
Reopens the websocket on close. Prevents badly configured reverse proxies from making the application stop working. In my testing, I've noticed that the websocket simply reopens when the connection is closed. Instead of setting error state to true on websocket close, we just clear the websocket out using the provided React `setWs` function. 