### PR TITLE
FIX:  Update docker-compose.yaml to handle bundled/unbundled SearXNG installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ There are mainly 2 ways of installing Perplexica - With Docker, Without Docker. 
 5. Ensure you are in the directory containing the `docker-compose.yaml` file and execute:
 
    ```bash
-   docker-compose --profile bundled up -d
+   docker compose --profile bundled up -d
    ```
 
 **Note**: `--profile bundled` installs SearXNG locally. If you are using an externally managed SearXNG instance omit this profile.

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ There are mainly 2 ways of installing Perplexica - With Docker, Without Docker. 
 5. Ensure you are in the directory containing the `docker-compose.yaml` file and execute:
 
    ```bash
-   docker compose up -d
+   docker-compose --profile bundled up -d
    ```
+
+**Note**: `--profile bundled` installs SearXNG locally. If you are using an externally managed SearXNG instance omit this profile.
 
 6. Wait a few minutes for the setup to complete. You can access Perplexica at http://localhost:3000 in your web browser.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
     networks:
       - perplexica-network
     restart: unless-stopped
+    profiles:
+      - bundled
 
   perplexica-backend:
     build:
@@ -16,8 +18,6 @@ services:
     image: itzcrazykns1337/perplexica-backend:main
     environment:
       - SEARXNG_API_URL=http://searxng:8080
-    depends_on:
-      - searxng
     ports:
       - 3001:3001
     volumes:


### PR DESCRIPTION
I have modified docker-compose.yaml to include a bundled profile for SearXNG. This allows you to skip installing SearXNG if you're using an externally hosted instance in your config.toml without having to modify the docker-compose file itself.

Does not install SearXNG:

   ```bash
   docker compose up -d
   ```

Does install SearXNG:

   ```bash
   docker compose --profile bundled up -d
   ```

**Note:** This required removing `depends_on: - searxng` from perplexica-backend. Currently there is no way to gracefully handle conditional profile dependencies in docker-compose files (that I know of). However, this really is not a problem as SearXNG will be installed first for bundled installs and perplexica-backend doesn't actually depend upon it to install/run. Please let me know if you have any questions/concerns with this PR. Love this project!