### PR TITLE
Fix the Docker Compose to mount the `config.toml` volume as file and not a directory 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - 3001:3001
     volumes:
       - backend-dbstore:/home/perplexica/data
-      - ./config.toml:/home/perplexica/config.toml
+      - ./config.toml:/home/perplexica/config.toml:rw
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     networks:


### PR DESCRIPTION
Fix an error on the `docker-compose.yaml` file since the `config.toml` volume mount does not specify the correct type.

It is mounting `config.toml` as a directory instead of a file:

```bash
docker compose up

[+] Running 2/0
 ✔ Container perplexica-searxng-1                             Running    0.0s                                                                                                                    
 ✔ Container perplexica-perplexica-frontend-1         Created   0.0s                                                                                                                           
Attaching to perplexica-backend-1, perplexica-frontend-1, searxng-1
Gracefully stopping... (press Ctrl+C again to force)
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/Users/damien/ProjectsJS/Perplexica/config.toml" to rootfs at "/home/perplexica": mount /Users/damien/ProjectsJS/Perplexica/config.toml:/home/perplexica (via /proc/self/fd/6), flags: 0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
```