### PR TITLE
Fix: Enter key interrupts IME composition in MessageInput component

### DIFF
--- a/ui/components/MessageInput.tsx
+++ b/ui/components/MessageInput.tsx
@@ -16,6 +16,7 @@ const MessageInput = ({
   const [message, setMessage] = useState('');
   const [textareaRows, setTextareaRows] = useState(1);
   const [mode, setMode] = useState<'multi' | 'single'>('single');
+  const [isComposing, setIsComposing] = useState(false);
 
   useEffect(() => {
     if (textareaRows >= 2 && message && mode === 'single') {
@@ -58,7 +59,7 @@ const MessageInput = ({
         setMessage('');
       }}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' && !e.shiftKey && !loading) {
+        if (e.key === 'Enter' && !e.shiftKey && !loading && !isComposing) {
           e.preventDefault();
           sendMessage(message);
           setMessage('');
@@ -74,6 +75,8 @@ const MessageInput = ({
         ref={inputRef}
         value={message}
         onChange={(e) => setMessage(e.target.value)}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
         onHeightChange={(height, props) => {
           setTextareaRows(Math.ceil(height / props.rowHeight));
         }}


### PR DESCRIPTION
**Summary**
This PR fixes an issue in the MessageInput component where pressing the Enter key during IME (Input Method Editor) composition interrupts the composition process. Users typing in languages that require IME input, such as Korean, Chinese, or Japanese, are affected by this bug.

**Problem**
When users are composing text using an IME, the onKeyDown event handler does not account for the composition state. Pressing the Enter key during composition prematurely ends the process, resulting in incomplete characters or leaving residual text in the input field.

**Related Issue**
Closes #443 

**Checklist**
- [x] Tested the changes locally
- [x] npm run format:write to format the code