### PR TITLE
add db setup to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ Before diving into coding, setting up your local environment is key. Here's what
 1. In the root directory, locate the `sample.config.toml` file.
 2. Rename it to `config.toml` and fill in the necessary configuration fields specific to the backend.
 3. Run `npm install` to install dependencies.
-4. Use `npm run dev` to start the backend in development mode.
+4. Run `npm run db:push` to set up the local sqlite.
+5. Use `npm run dev` to start the backend in development mode.
 
 ### Frontend
 


### PR DESCRIPTION
When running the development mode on my machine I got following errors:
```sh
error: Failed to handle message: SqliteError: no such table: chats
error: Unhandled Rejection at: [object Promise], reason: SqliteError: no such table: messages
```
Running `npm run db:push` solved the problem.
So I added it to the CONTRIBUTING.md