### PR TITLE
fix(llm-markdown-code-rendering)

### DIFF
--- a/ui/components/MessageBox.tsx
+++ b/ui/components/MessageBox.tsx
@@ -51,11 +51,15 @@ const MessageBox = ({
       message.sources.length > 0
     ) {
       return setParsedMessage(
-        message.content.replace(
-          regex,
-          (_, number) =>
-            `<a href="${message.sources?.[number - 1]?.metadata?.url}" target="_blank" className="bg-light-secondary dark:bg-dark-secondary px-1 rounded ml-1 no-underline text-xs text-black/70 dark:text-white/70 relative">${number}</a>`,
-        ),
+        message.content
+          .replace(
+            regex,
+            (_, number) =>
+              `<a href="${message.sources?.[number - 1]?.metadata?.url}" target="_blank" className="bg-light-secondary dark:bg-dark-secondary px-1 rounded ml-1 no-underline text-xs text-black/70 dark:text-white/70 relative">${number}</a>`,
+          )
+          .replace(/(\*\*.*?\*\*\s*)(\s*```[\s\S]*?```)/g, (match, p1, p2) => {
+            return `${p1}\n${p2.trim()}`;
+          }),
       );
     }
 


### PR DESCRIPTION
The issue with text processing when the LLM model returns incorrect Markdown code when ``` is immediately followed by other text has been resolved.

Here is an example of problem (replace ~ with `):
```markdown
**Create a systemd service file:**
~~~sh
nano ~/.config/systemd/user/waybar.service
~~~
```