### PR TITLE
feat(anthropic): update chat models to include Claude 3.5 Haiku and new version for Sonnet

### DIFF
--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -9,12 +9,20 @@ export const loadAnthropicChatModels = async () => {
 
   try {
     const chatModels = {
-      'claude-3-5-sonnet-20240620': {
+      'claude-3-5-sonnet-20241022': {
         displayName: 'Claude 3.5 Sonnet',
         model: new ChatAnthropic({
           temperature: 0.7,
           anthropicApiKey: anthropicApiKey,
-          model: 'claude-3-5-sonnet-20240620',
+          model: 'claude-3-5-sonnet-20241022',
+        }),
+      },
+      'claude-3-5-haiku-20241022': {
+        displayName: 'Claude 3.5 Haiku',
+        model: new ChatAnthropic({
+          temperature: 0.7,
+          anthropicApiKey: anthropicApiKey,
+          model: 'claude-3-5-haiku-20241022',
         }),
       },
       'claude-3-opus-20240229': {


### PR DESCRIPTION
Updates to chat models:

* Updated the model identifier for `claude-3-5-sonnet` to a new version (`claude-3-5-sonnet-20241022`).
* Added a new chat model `claude-3-5-haiku` with its configuration.