### PR TITLE
[bug-fix] Delete msgs only belonging to the chat

### DIFF
--- a/src/websocket/messageHandler.ts
+++ b/src/websocket/messageHandler.ts
@@ -5,7 +5,7 @@ import type { Embeddings } from '@langchain/core/embeddings';
 import logger from '../utils/logger';
 import db from '../db';
 import { chats, messages as messagesSchema } from '../db/schema';
-import { eq, asc, gt } from 'drizzle-orm';
+import { eq, asc, gt, and } from 'drizzle-orm';
 import crypto from 'crypto';
 import { getFileDetails } from '../utils/files';
 import MetaSearchAgent, {
@@ -238,7 +238,7 @@ export const handleMessage = async (
           } else {
             await db
               .delete(messagesSchema)
-              .where(gt(messagesSchema.id, messageExists.id))
+              .where(and(gt(messagesSchema.id, messageExists.id), eq(messagesSchema.chatId, parsedMessage.chatId)))
               .execute();
           }
         } catch (err) {


### PR DESCRIPTION
I noticed that whenever I use `Rewrite` on older Chat, the messages in the newer ones get deleted. I traced it to `messageHandler.ts`.

In `src/websocket/messageHandler.ts` we delete all msgs greater than the `messageId`. However we delete all the messages instead of the ones only belonging to that particular chat.

Fixed it by adding `eq chatId` to the delete query.