### PR TITLE
Support relative subpaths for NEXT_PUBLIC_WS_URL 

### DIFF
--- a/ui/components/ChatWindow.tsx
+++ b/ui/components/ChatWindow.tsx
@@ -402,11 +402,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
     websocketUrl = `${protocol}${host}${path}`;
   }
 
-  const ws = useSocket(
-    websocketUrl,
-    setIsWSReady,
-    setHasError,
-  );
+  const ws = useSocket(websocketUrl, setIsWSReady, setHasError);
 
   const [loading, setLoading] = useState(false);
   const [messageAppeared, setMessageAppeared] = useState(false);

--- a/ui/components/ChatWindow.tsx
+++ b/ui/components/ChatWindow.tsx
@@ -393,8 +393,17 @@ const ChatWindow = ({ id }: { id?: string }) => {
   const [isReady, setIsReady] = useState(false);
 
   const [isWSReady, setIsWSReady] = useState(false);
+
+  let websocketUrl = process.env.NEXT_PUBLIC_WS_URL!;
+  if (websocketUrl.startsWith('/')) {
+    const protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
+    const host = window.location.host;
+    const path = websocketUrl;
+    websocketUrl = `${protocol}${host}${path}`;
+  }
+
   const ws = useSocket(
-    process.env.NEXT_PUBLIC_WS_URL!,
+    websocketUrl,
     setIsWSReady,
     setHasError,
   );


### PR DESCRIPTION
Enables the definition of relative subpaths for NEXT_PUBLIC_WS_URL in order to be able to create prebuild containers with subpaths.

Example build see: https://github.com/niki-on-github/Perplexica/blob/e11d2cd26c7dd63f18ccd787028c22a688614e52/.github/workflows/docker-image.yaml#L31

Example usage see: https://github.com/niki-on-github/nixos-k3s/blob/c7da7d1941b0d2abf4198f211588bc086892bfaa/kubernetes/apps/perplexica/app/app.yaml

This allows people with reverse proxy to build a pre-built container with relative sub-paths (if they host both services on the same domain). Workaround for #570