### PR TITLE
[fix] Problems with overlapping specific turns when generating LLM final answers

### DIFF
--- a/ui/components/ChatWindow.tsx
+++ b/ui/components/ChatWindow.tsx
@@ -413,6 +413,8 @@ const ChatWindow = ({ id }: { id?: string }) => {
 
   const [isMessagesLoaded, setIsMessagesLoaded] = useState(false);
 
+  const [pendingRewrite, setPendingRewrite] = useState<{ content: string; messageId: string } | null>(null);
+
   const [notFound, setNotFound] = useState(false);
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -451,6 +453,12 @@ const ChatWindow = ({ id }: { id?: string }) => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const chatHistoryRef = useRef<[string, string][]>([]);
+
+  useEffect(() => {
+    chatHistoryRef.current = chatHistory;
+  }, [chatHistory]);
 
   const messagesRef = useRef<Message[]>([]);
 
@@ -494,7 +502,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
         files: fileIds,
         focusMode: focusMode,
         optimizationMode: optimizationMode,
-        history: [...chatHistory, ['human', message]],
+        history: [...chatHistoryRef.current],
       }),
     );
 
@@ -609,14 +617,21 @@ const ChatWindow = ({ id }: { id?: string }) => {
     const message = messages[index - 1];
 
     setMessages((prev) => {
-      return [...prev.slice(0, messages.length > 2 ? index - 1 : 0)];
+      return [...prev.slice(0, messages.length >= 2 ? index - 1 : 0)];
     });
     setChatHistory((prev) => {
-      return [...prev.slice(0, messages.length > 2 ? index - 1 : 0)];
+      return [...prev.slice(0, messages.length >= 2 ? index - 1 : 0)];
     });
 
-    sendMessage(message.content, message.messageId);
+    setPendingRewrite({content: message.content, messageId: message.messageId});
   };
+
+  useEffect(() => {
+    if (pendingRewrite) {
+      sendMessage(pendingRewrite.content, pendingRewrite.messageId);
+      setPendingRewrite(null);
+    }
+  }, [chatHistory]);
 
   useEffect(() => {
     if (isReady && initialMessage && ws?.readyState === 1) {


### PR DESCRIPTION
There is an issue in the `metaSearchAgent.ts` code where the user turn is duplicated when the following code executes. This can be critical when the user's input is long.

```typescript
      ChatPromptTemplate.fromMessages([
        ['system', this.config.responsePrompt],
        new MessagesPlaceholder('chat_history'),
        ['user', '{query}'],
      ]),
```

Additionally, in the `ChatWindow.tsx` code, there is an issue where the rewrite function continues to use the past `ChatHistory` as is. Since LLMs tend to generate similar responses when the same user input appears in previous turns, this can negatively impact the performance of the rewrite function.

Thanks.