### PR TITLE
fix(ui): improve dark mode text color for attachment buttons

### DIFF
--- a/ui/components/MessageInputActions/Attach.tsx
+++ b/ui/components/MessageInputActions/Attach.tsx
@@ -145,7 +145,7 @@ const Attach = ({
                   <div className="bg-dark-100 flex items-center justify-center w-10 h-10 rounded-md">
                     <File size={16} className="text-white/70" />
                   </div>
-                  <p className="text-white/70 text-sm">
+                  <p className="text-black/70 dark:text-white/70 text-sm">
                     {file.fileName.length > 25
                       ? file.fileName.replace(/\.\w+$/, '').substring(0, 25) +
                         '...' +

--- a/ui/components/MessageInputActions/Attach.tsx
+++ b/ui/components/MessageInputActions/Attach.tsx
@@ -110,7 +110,7 @@ const Attach = ({
                 <button
                   type="button"
                   onClick={() => fileInputRef.current.click()}
-                  className="flex flex-row items-center space-x-1 text-white/70 hover:text-white transition duration-200"
+                  className="flex flex-row items-center space-x-1 text-black/70 dark:text-white/70 hover:text-black hover:dark:text-white transition duration-200"
                 >
                   <input
                     type="file"
@@ -128,7 +128,7 @@ const Attach = ({
                     setFiles([]);
                     setFileIds([]);
                   }}
-                  className="flex flex-row items-center space-x-1 text-white/70 hover:text-white transition duration-200"
+                  className="flex flex-row items-center space-x-1 text-black/70 dark:text-white/70 hover:text-black hover:dark:text-white transition duration-200"
                 >
                   <Trash size={14} />
                   <p className="text-xs">Clear</p>

--- a/ui/components/MessageInputActions/AttachSmall.tsx
+++ b/ui/components/MessageInputActions/AttachSmall.tsx
@@ -82,7 +82,7 @@ const AttachSmall = ({
                 <button
                   type="button"
                   onClick={() => fileInputRef.current.click()}
-                  className="flex flex-row items-center space-x-1 text-white/70 hover:text-white transition duration-200"
+                  className="flex flex-row items-center space-x-1 text-black/70 dark:text-white/70 hover:text-black hover:dark:text-white transition duration-200"
                 >
                   <input
                     type="file"
@@ -100,7 +100,7 @@ const AttachSmall = ({
                     setFiles([]);
                     setFileIds([]);
                   }}
-                  className="flex flex-row items-center space-x-1 text-white/70 hover:text-white transition duration-200"
+                  className="flex flex-row items-center space-x-1 text-black/70 dark:text-white/70 hover:text-black hover:dark:text-white transition duration-200"
                 >
                   <Trash size={14} />
                   <p className="text-xs">Clear</p>

--- a/ui/components/MessageInputActions/AttachSmall.tsx
+++ b/ui/components/MessageInputActions/AttachSmall.tsx
@@ -117,7 +117,7 @@ const AttachSmall = ({
                   <div className="bg-dark-100 flex items-center justify-center w-10 h-10 rounded-md">
                     <File size={16} className="text-white/70" />
                   </div>
-                  <p className="text-white/70 text-sm">
+                  <p className="text-black/70 dark:text-white/70 text-sm">
                     {file.fileName.length > 25
                       ? file.fileName.replace(/\.\w+$/, '').substring(0, 25) +
                         '...' +


### PR DESCRIPTION
Fixed the bug where the attachment upload add button and delete button were invisible under the light theme, and optimized the hover effect in the light theme.

<img width="1136" alt="dark" src="https://github.com/user-attachments/assets/e9aad36d-0030-44b1-bd42-6c062f5167b2" />

<img width="1113" alt="light" src="https://github.com/user-attachments/assets/a718ea69-4fa0-476c-879b-864f19997baf" />

