### PR TITLE
Only set scrollIntoView for user msg.

### DIFF
--- a/ui/components/Chat.tsx
+++ b/ui/components/Chat.tsx
@@ -48,10 +48,16 @@ const Chat = ({
   });
 
   useEffect(() => {
-    messageEnd.current?.scrollIntoView({ behavior: 'smooth' });
+    const scroll = () => {
+      messageEnd.current?.scrollIntoView({ behavior: 'smooth' });
+    };
 
     if (messages.length === 1) {
       document.title = `${messages[0].content.substring(0, 30)} - Perplexica`;
+    }
+
+    if (messages[messages.length - 1]?.role == 'user') {
+      scroll();
     }
   }, [messages]);
 


### PR DESCRIPTION
Only automatically scroll to the latest chat msg from the user without continuing to move while receiving the responses from the assistant. This's to address - https://github.com/ItzCrazyKns/Perplexica/issues/671 