### PR TITLE
Add Optional Environment Variables Config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,8 @@ services:
       dockerfile: app.dockerfile
     environment:
       - SEARXNG_API_URL=http://searxng:8080
+    env_file:
+      - .env
     ports:
       - 3000:3000
     networks:

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -45,32 +45,62 @@ const loadConfig = () =>
     fs.readFileSync(path.join(process.cwd(), `${configFileName}`), 'utf-8'),
   ) as any as Config;
 
+const getEnvVar = (key: string): string | undefined => {
+  return process.env[key];
+};
+
+const getConfigValue = (path: string[], defaultValue: string): string => {
+  // Convert path to environment variable name (e.g., ['MODELS', 'GROQ', 'API_KEY'] -> 'GROQ_API_KEY')
+  const envKey = path.slice(1).join('_').toUpperCase();
+  const envValue = getEnvVar(envKey);
+
+  if (envValue !== undefined) {
+    return envValue;
+  }
+
+  // Fall back to config.toml
+  let value: any = loadConfig();
+  for (const key of path) {
+    value = value[key];
+    if (value === undefined) {
+      return defaultValue;
+    }
+  }
+  return value;
+};
+
 export const getSimilarityMeasure = () =>
-  loadConfig().GENERAL.SIMILARITY_MEASURE;
+  getConfigValue(['GENERAL', 'SIMILARITY_MEASURE'], 'cosine');
 
-export const getKeepAlive = () => loadConfig().GENERAL.KEEP_ALIVE;
+export const getKeepAlive = () =>
+  getConfigValue(['GENERAL', 'KEEP_ALIVE'], '30s');
 
-export const getOpenaiApiKey = () => loadConfig().MODELS.OPENAI.API_KEY;
+export const getOpenaiApiKey = () =>
+  getConfigValue(['MODELS', 'OPENAI', 'API_KEY'], '');
 
-export const getGroqApiKey = () => loadConfig().MODELS.GROQ.API_KEY;
+export const getGroqApiKey = () =>
+  getConfigValue(['MODELS', 'GROQ', 'API_KEY'], '');
 
-export const getAnthropicApiKey = () => loadConfig().MODELS.ANTHROPIC.API_KEY;
+export const getAnthropicApiKey = () =>
+  getConfigValue(['MODELS', 'ANTHROPIC', 'API_KEY'], '');
 
-export const getGeminiApiKey = () => loadConfig().MODELS.GEMINI.API_KEY;
+export const getGeminiApiKey = () =>
+  getConfigValue(['MODELS', 'GEMINI', 'API_KEY'], '');
 
 export const getSearxngApiEndpoint = () =>
-  process.env.SEARXNG_API_URL || loadConfig().API_ENDPOINTS.SEARXNG;
+  getConfigValue(['API_ENDPOINTS', 'SEARXNG'], '');
 
-export const getOllamaApiEndpoint = () => loadConfig().MODELS.OLLAMA.API_URL;
+export const getOllamaApiEndpoint = () =>
+  getConfigValue(['MODELS', 'OLLAMA', 'API_URL'], 'http://localhost:11434');
 
 export const getCustomOpenaiApiKey = () =>
-  loadConfig().MODELS.CUSTOM_OPENAI.API_KEY;
+  getConfigValue(['MODELS', 'CUSTOM_OPENAI', 'API_KEY'], '');
 
 export const getCustomOpenaiApiUrl = () =>
-  loadConfig().MODELS.CUSTOM_OPENAI.API_URL;
+  getConfigValue(['MODELS', 'CUSTOM_OPENAI', 'API_URL'], '');
 
 export const getCustomOpenaiModelName = () =>
-  loadConfig().MODELS.CUSTOM_OPENAI.MODEL_NAME;
+  getConfigValue(['MODELS', 'CUSTOM_OPENAI', 'MODEL_NAME'], '');
 
 const mergeConfigs = (current: any, update: any): any => {
   if (update === null || update === undefined) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -40,10 +40,13 @@ type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
 
-const loadConfig = () =>
-  toml.parse(
-    fs.readFileSync(path.join(process.cwd(), `${configFileName}`), 'utf-8'),
-  ) as any as Config;
+const loadConfig = () => {
+  const configPath = path.join(process.cwd(), configFileName);
+  if (!fs.existsSync(configPath) || fs.lstatSync(configPath).isDirectory()) {
+    return {} as Config;
+  }
+  return toml.parse(fs.readFileSync(configPath, 'utf-8')) as any as Config;
+};
 
 const getEnvVar = (key: string): string | undefined => {
   return process.env[key];
@@ -88,7 +91,7 @@ export const getGeminiApiKey = () =>
   getConfigValue(['MODELS', 'GEMINI', 'API_KEY'], '');
 
 export const getSearxngApiEndpoint = () =>
-  getConfigValue(['API_ENDPOINTS', 'SEARXNG'], '');
+  process.env.SEARXNG_API_URL || getConfigValue(['API_ENDPOINTS', 'SEARXNG'], '');
 
 export const getOllamaApiEndpoint = () =>
   getConfigValue(['MODELS', 'OLLAMA', 'API_URL'], 'http://localhost:11434');


### PR DESCRIPTION
I use a hosting tool called Coolify, and it would be neat if we could host the app without having to modify the `config.toml` file, which would make hosting on Coolify much easier. The de-facto method for configuring apps is via Environment Variables, so I've made them a configuration option when deploying Perplexica. This does not affect existing functionality, however env vars do take precedence over the `config.toml` file if present, as it is common for users who use a lot of AI tools to keep an API key in their environment variables system-wide (though not the most secure thing to do).

## Usage Example
To configure Perplexica without a `config.toml` file, users can set environment variables like:

```sh
GROQ_API_KEY=your_groq_key
OPENAI_API_KEY=your_openai_key
SIMILARITY_MEASURE=cosine
KEEP_ALIVE=60s
SEARXNG_API_URL=http://searxng:8080
```
These can be provided via a `.env` file or directly in the deployment environment.

## Notes
- Environment variable names are derived from the config path (e.g., `MODELS.OPENAI.API_KEY` becomes `OPENAI_API_KEY`).
- The `SEARXNG_API_URL` environment variable retains its precedence over the config for consistency with prior behavior.