### PR TITLE
feat(message-box): support [1,2,3,4] citation format instead of just [1][2][3]

### DIFF
--- a/src/components/MessageBox.tsx
+++ b/src/components/MessageBox.tsx
@@ -68,45 +68,34 @@ const MessageBox = ({
     ) {
       setParsedMessage(
         processedMessage.replace(
-          citationRegex, // Use the updated regex
-          (match, capturedContent) => { // match is the full "[1,2,3]", capturedContent is "1,2,3"
-            // Split the captured content by comma, trim whitespace, and filter out non-digits
+          citationRegex,
+          (_, capturedContent: string) => {
             const numbers = capturedContent
               .split(',')
-              .map(numStr => numStr.trim())
-              .filter(numStr => /^\d+$/.test(numStr)); // Ensure it's only digits
+              .map((numStr) => numStr.trim())
 
-            // If no valid numbers found after split/filter (e.g., "[]" or "[abc]"), return original match
-            if (numbers.length === 0) {
-              return match;
-            }
+            const linksHtml = numbers
+              .map((numStr) => {
+                const number = parseInt(numStr);
 
-            // Generate an HTML link for each valid number found
-            const linksHtml = numbers.map(numStr => {
-              const number = parseInt(numStr, 10); // Convert string to integer for array indexing
+                if (isNaN(number) || number <= 0) {
+                  return `[${numStr}]`;
+                }
 
-              // Basic validation: Ensure it's a positive number
-              if (isNaN(number) || number <= 0) {
-                // Return the original number part as text if invalid for lookup
-                return `[${numStr}]`;
-              }
+                const source = message.sources?.[number - 1];
+                const url = source?.metadata?.url;
 
-              // Get the corresponding source, adjusting for 0-based index
-              const source = message.sources?.[number - 1];
-              const url = source?.metadata?.url;
-
-              // If URL exists, create the link
-              if (url) {
-                return `<a href="${url}" target="_blank" className="bg-light-secondary dark:bg-dark-secondary px-1 rounded ml-1 no-underline text-xs text-black/70 dark:text-white/70 relative">${numStr}</a>`;
-              } else {
-                // If no URL found for this number, return the number styled similarly but red
-                return `<span className="bg-light-secondary dark:bg-dark-secondary px-1 rounded ml-1 text-xs relative font-medium text-red-600 dark:text-red-400">${numStr}</span>`;
-              }
-            }).join(''); // Join the generated links (or fallback text) together without separators
+                if (url) {
+                  return `<a href="${url}" target="_blank" className="bg-light-secondary dark:bg-dark-secondary px-1 rounded ml-1 no-underline text-xs text-black/70 dark:text-white/70 relative">${numStr}</a>`;
+                } else {
+                  return `[${numStr}]`;
+                }
+              })
+              .join('');
 
             return linksHtml;
-          }
-        )
+          },
+        ),
       );
       return;
     }


### PR DESCRIPTION
Unlike larger local LLMs, smaller ones inconsistently format citations, outputting styles like [1][2][3], [1,2,3,4,5], or [1,2][3]. 

This pull request introduces changes to recognize and support all these variations.