### PR TITLE
Adding user session for chat history

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -29,6 +29,7 @@ type Message = {
   messageId: string;
   chatId: string;
   content: string;
+  userSessionId: string;
 };
 
 type ChatModel = {
@@ -138,6 +139,7 @@ const handleHistorySave = async (
     where: eq(chats.id, message.chatId),
   });
 
+  let currentDate = new Date();
   if (!chat) {
     await db
       .insert(chats)
@@ -147,6 +149,8 @@ const handleHistorySave = async (
         createdAt: new Date().toString(),
         focusMode: focusMode,
         files: files.map(getFileDetails),
+        userSessionId: message.userSessionId,
+        timestamp: currentDate.toISOString(),
       })
       .execute();
   }

--- a/src/app/api/chats/route.ts
+++ b/src/app/api/chats/route.ts
@@ -1,10 +1,47 @@
 import db from '@/lib/db';
+import { chats } from '@/lib/db/schema';
+import { eq, sql} from 'drizzle-orm';
 
 export const GET = async (req: Request) => {
   try {
-    let chats = await db.query.chats.findMany();
-    chats = chats.reverse();
-    return Response.json({ chats: chats }, { status: 200 });
+    // get header from request
+    const headers = await req.headers;
+    let userSessionId = headers.get('user-session-id')?.toString() ?? '';
+
+    if (userSessionId == '') {
+      return Response.json({ chats: {} }, { status: 200 });
+    }
+    
+    let chatsRes = await db.query.chats.findMany({
+      where: eq(chats.userSessionId, userSessionId),
+    });
+    
+    chatsRes = chatsRes.reverse();
+    // Keep only the latest 20 records in the database. Delete older records.
+    let maxRecordLimit = 20;
+    if (chatsRes.length > maxRecordLimit) {
+      const deleteChatsQuery = sql`DELETE FROM chats
+        WHERE userSessionId = ${userSessionId} AND (
+          timestamp IS NULL OR
+          timestamp NOT in (
+            SELECT timestamp FROM chats
+            WHERE userSessionId = ${userSessionId}
+            ORDER BY timestamp DESC
+            LIMIT ${maxRecordLimit}
+          )
+        )
+      `;
+      await db.run(deleteChatsQuery);
+      // Delete messages that no longer link with the chat from the database.
+      const deleteMessagesQuery = sql`DELETE FROM messages
+        WHERE chatId NOT IN (
+          SELECT id FROM chats
+        )
+      `;
+      await db.run(deleteMessagesQuery);
+    }
+
+    return Response.json({ chats: chatsRes }, { status: 200 });
   } catch (err) {
     console.error('Error in getting chats: ', err);
     return Response.json(

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import crypto from 'crypto';
 import DeleteChat from '@/components/DeleteChat';
 import { cn, formatTimeDifference } from '@/lib/utils';
 import { BookOpenText, ClockIcon, Delete, ScanEye } from 'lucide-react';
@@ -21,10 +22,17 @@ const Page = () => {
     const fetchChats = async () => {
       setLoading(true);
 
+      let userSessionId = localStorage.getItem('userSessionId');
+      if (!userSessionId) {
+        userSessionId = crypto.randomBytes(20).toString('hex');
+        localStorage.setItem('userSessionId', userSessionId)
+      }
+
       const res = await fetch(`/api/chats`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
+          'user-session-id': userSessionId!,
         },
       });
 

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -95,6 +95,12 @@ const checkConfig = async (
       if (!embeddingModel || !embeddingModelProvider) {
         const embeddingModelProviders = providers.embeddingModelProviders;
 
+        let userSessionId = localStorage.getItem('userSessionId');
+        if (!userSessionId) {
+          userSessionId = crypto.randomBytes(20).toString('hex');
+          localStorage.setItem('userSessionId', userSessionId!)
+        }
+
         if (
           !embeddingModelProviders ||
           Object.keys(embeddingModelProviders).length === 0
@@ -342,6 +348,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
     let added = false;
 
     messageId = messageId ?? crypto.randomBytes(7).toString('hex');
+    let userSessionId = localStorage.getItem('userSessionId');
 
     setMessages((prevMessages) => [
       ...prevMessages,
@@ -466,6 +473,7 @@ const ChatWindow = ({ id }: { id?: string }) => {
           messageId: messageId,
           chatId: chatId!,
           content: message,
+          userSessionId: userSessionId,
         },
         chatId: chatId!,
         files: fileIds,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -25,4 +25,6 @@ export const chats = sqliteTable('chats', {
   files: text('files', { mode: 'json' })
     .$type<File[]>()
     .default(sql`'[]'`),
+  userSessionId: text('userSessionId'),
+  timestamp: text('timestamp'),
 });


### PR DESCRIPTION
Similar to https://github.com/ItzCrazyKns/Perplexica/pull/268 but re-base from the latest after ~ a year

Currently, the chat history's shared globally for all users/sessions. This pull request isolates chat history by implementing user-specific chat history. This ensures that each user's chat history is contained within their individual sessions. Also to keep things tidy, keep the history for the last 20 chats per sessionid.

Please note that this implementation does not include any advanced or basic authentication, and there is no guarantee of security or privacy.