### PR TITLE
docs: add ClawCloud Run button

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Perplexica runs on Next.js and handles all API requests. It works right away on 
 
 [![Deploy to Sealos](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://usw.sealos.io/?openapp=system-template%3FtemplateName%3Dperplexica)
 [![Deploy to RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=267)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=U11MRQ8U9RM4&openapp=system-fastdeploy%3FtemplateName%3Dperplexica)
 
 ## Upcoming Features
 


### PR DESCRIPTION
docs: add ClawCloud Run button

---
We are **ClawCloud Run** — a cloud-native deployment platform where users can deploy your application with one click. The referral code within the deployment link is just for anonymous traffic analytics in order to improve our platform. If you’d like to use your own code, just sign up on ClawCloud Run and replace it in seconds.