### PR TITLE
Feature/flexible ollama

### DIFF
--- a/sample.config.toml
+++ b/sample.config.toml
@@ -21,6 +21,8 @@ MODEL_NAME = ""
 
 [MODELS.OLLAMA]
 API_URL = "" # Ollama API URL - http://host.docker.internal:11434
+API_KEY = ""
+MODEL_NAME = ""
 
 [MODELS.DEEPSEEK]
 API_KEY = ""

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -31,6 +31,8 @@ interface Config {
     };
     OLLAMA: {
       API_URL: string;
+      API_KEY: string;
+      MODEL_NAME: string;
     };
     DEEPSEEK: {
       API_KEY: string;
@@ -82,6 +84,8 @@ export const getSearxngApiEndpoint = () =>
   process.env.SEARXNG_API_URL || loadConfig().API_ENDPOINTS.SEARXNG;
 
 export const getOllamaApiEndpoint = () => loadConfig().MODELS.OLLAMA.API_URL;
+export const getOllamaApiKey = () => loadConfig().MODELS.OLLAMA.API_KEY;
+export const getOllamaModelName = () => loadConfig().MODELS.OLLAMA.MODEL_NAME;
 
 export const getDeepseekApiKey = () => loadConfig().MODELS.DEEPSEEK.API_KEY;
 

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -104,7 +104,8 @@ export const getAvailableChatModelProviders = async () => {
   const customOpenAiApiUrl = getCustomOpenaiApiUrl();
   const customOpenAiModelName = getCustomOpenaiModelName();
 
-  models['custom_openai'] = {
+  if (customOpenAiApiKey && customOpenAiApiUrl && customOpenAiModelName) {
+    models['custom_openai'] = {
     ...(customOpenAiApiKey && customOpenAiApiUrl && customOpenAiModelName
       ? {
           [customOpenAiModelName]: {
@@ -120,6 +121,7 @@ export const getAvailableChatModelProviders = async () => {
           },
         }
       : {}),
+    };
   };
 
   return models;


### PR DESCRIPTION
- Improved Ollama configuration: Added API_KEY and MODEL_NAME configuration options
- Add custom_openai models only if custom_openai is configured - because old behavior disturbes ollama-only usage