### PR TITLE
fix(discover): provide language when fetching

### DIFF
--- a/src/app/api/discover/route.ts
+++ b/src/app/api/discover/route.ts
@@ -36,6 +36,7 @@ export const GET = async (req: Request) => {
                   {
                     engines: ['bing news'],
                     pageno: 1,
+                    language: "en",
                   },
                 )
               ).results;
@@ -49,7 +50,11 @@ export const GET = async (req: Request) => {
       data = (
         await searchSearxng(
           `site:${articleWebsites[Math.floor(Math.random() * articleWebsites.length)]} ${topics[Math.floor(Math.random() * topics.length)]}`,
-          { engines: ['bing news'], pageno: 1 },
+          {
+            engines: ['bing news'],
+            pageno: 1,
+            language: "en"
+          },
         )
       ).results;
     }


### PR DESCRIPTION
## Summary

Provide language code via `opts` when fetching search for discover page

Related documentation
- https://docs.searxng.org/dev/search_api.html

## Related issue

Some engines provide empty response when no language is provided.

Related to #618

## How is this tested?

Tested locally 

| Before | After |
| -- | -- |
| <img width="2396" height="1294" alt="image" src="https://github.com/user-attachments/assets/8a6a986d-2130-4661-9d16-a2ff0b6de0f0" /> | <img width="2396" height="1294" alt="image" src="https://github.com/user-attachments/assets/49330f9e-f8ca-4ec4-8ae2-d8abf516c3a8" />
