### PR TITLE
feat: Add support for latest AI models from Anthropic, Google, & OpenAI

### DIFF
--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -10,6 +10,18 @@ import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 const anthropicChatModels: Record<string, string>[] = [
   {
+    displayName: 'Claude 4.1 Opus',
+    key: 'claude-opus-4-1-20250805',
+  },
+  {
+    displayName: 'Claude 4 Opus',
+    key: 'claude-opus-4-20250514',
+  },
+  {
+    displayName: 'Claude 4 Sonnet',
+    key: 'claude-sonnet-4-20250514',
+  },
+  {
     displayName: 'Claude 3.7 Sonnet',
     key: 'claude-3-7-sonnet-20250219',
   },

--- a/src/lib/providers/gemini.ts
+++ b/src/lib/providers/gemini.ts
@@ -18,6 +18,10 @@ const geminiChatModels: Record<string, string>[] = [
     key: 'gemini-2.5-flash',
   },
   {
+    displayName: 'Gemini 2.5 Flash-Lite',
+    key: 'gemini-2.5-flash-lite',
+  },
+  {
     displayName: 'Gemini 2.5 Pro',
     key: 'gemini-2.5-pro',
   },

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -81,7 +81,7 @@ export const loadOpenAIChatModels = async () => {
         model: new ChatOpenAI({
           apiKey: openaiApiKey,
           modelName: model.key,
-          temperature: 1,
+          temperature: model.key.includes('gpt-5') ? 1 : 0.7,
         }) as unknown as BaseChatModel,
       };
     });

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -42,6 +42,18 @@ const openaiChatModels: Record<string, string>[] = [
     displayName: 'GPT 4.1',
     key: 'gpt-4.1',
   },
+  {
+    displayName: 'GPT 5 nano',
+    key: 'gpt-5-nano',
+  },
+  {
+    displayName: 'GPT 5 mini',
+    key: 'gpt-5-mini',
+  },
+  {
+    displayName: 'GPT 5',
+    key: 'gpt-5',
+  },
 ];
 
 const openaiEmbeddingModels: Record<string, string>[] = [
@@ -69,7 +81,7 @@ export const loadOpenAIChatModels = async () => {
         model: new ChatOpenAI({
           apiKey: openaiApiKey,
           modelName: model.key,
-          temperature: 0.7,
+          temperature: 1,
         }) as unknown as BaseChatModel,
       };
     });


### PR DESCRIPTION
Add support for the following new models:

- Anthropic
  - Claude Opus 4.1
  - Claude Opus 4
  - Claude Sonnet 4
- Google
  - Gemini 2.5 Flash-Lite
- OpenAI
  - GPT 5
  - GPT 5 Mini
  - GPT 5 Nano

* Changed the temperature for OpenAI models to `1` for [GPT 5 support](https://community.openai.com/t/temperature-in-gpt-5-models/1337133). 