### PR TITLE
make file icon in attachment modal in chat page fit light theme better

### DIFF
--- a/src/components/MessageInputActions/AttachSmall.tsx
+++ b/src/components/MessageInputActions/AttachSmall.tsx
@@ -107,8 +107,8 @@ const AttachSmall = () => {
                   key={i}
                   className="flex flex-row items-center justify-start w-full space-x-3 p-3"
                 >
-                  <div className="bg-dark-100 flex items-center justify-center w-10 h-10 rounded-md">
-                    <File size={16} className="text-white/70" />
+                  <div className="bg-light-100 dark:bg-dark-100 flex items-center justify-center w-10 h-10 rounded-md">
+                    <File size={16} className="text-black/70 dark:text-white/70" />
                   </div>
                   <p className="text-black/70 dark:text-white/70 text-sm">
                     {file.fileName.length > 25


### PR DESCRIPTION
make the file icon in the attachment modal for the chat page an off-white background so that it matches the light theme better and looks the same as the attachment modal on the home page (see #855).

Before:
<img width="696" height="184" alt="image" src="https://github.com/user-attachments/assets/bdbc2cc2-1f98-4a19-b6a4-fcae41a630b2" />

After:
<img width="694" height="181" alt="image" src="https://github.com/user-attachments/assets/1ffa4449-0bd9-436c-adc6-bb55df56d6c3" />

Dark mode is still fine:
<img width="694" height="177" alt="image" src="https://github.com/user-attachments/assets/d2f9c960-b44d-4715-8450-25a72b5b9eba" />
