### PR TITLE
validate the request body of api/chat to prevent malformed request body

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -22,26 +22,22 @@ import { z } from 'zod';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-// Message schema
 const messageSchema = z.object({
   messageId: z.string().min(1, 'Message ID is required'),
   chatId: z.string().min(1, 'Chat ID is required'),
   content: z.string().min(1, 'Message content is required'),
 });
 
-// ChatModel schema
 const chatModelSchema = z.object({
   provider: z.string().optional(),
   name: z.string().optional(),
 });
 
-// EmbeddingModel schema
 const embeddingModelSchema = z.object({
   provider: z.string().optional(),
   name: z.string().optional(),
 });
 
-// Main Body schema
 const bodySchema = z.object({
   message: messageSchema,
   optimizationMode: z.enum(['speed', 'balanced', 'quality'], {
@@ -69,8 +65,7 @@ const bodySchema = z.object({
 type Message = z.infer<typeof messageSchema>;
 type Body = z.infer<typeof bodySchema>;
 
-// Safe validation that returns success/error
-function safeValidateBody(data: unknown) {
+const safeValidateBody = (data: unknown) => {
   const result = bodySchema.safeParse(data);
 
   if (!result.success) {
@@ -87,7 +82,7 @@ function safeValidateBody(data: unknown) {
     success: true,
     data: result.data,
   };
-}
+};
 
 const handleEmitterEvents = async (
   stream: EventEmitter,


### PR DESCRIPTION
Fixes #579

To Resolve this used the zod schema and safe parse to check valide request body. This only reflect on the /api/chat API and not other api.

Checks:
Done: npm run format:write
Done: Unit testing using postman.
Done: Run production docker and play around the chat
Undone: handle this error on UI (No need to handle on UI side). Error reponse message handle by default 

<img width="1510" height="860" alt="image" src="https://github.com/user-attachments/assets/4f4efae5-43b1-476b-aa11-ad56632fb6ed" />
