### PR TITLE
fix: list all available gemini embedding models

### DIFF
--- a/src/lib/models/providers/gemini.ts
+++ b/src/lib/models/providers/gemini.ts
@@ -48,7 +48,7 @@ class GeminiProvider extends BaseModelProvider<GeminiConfig> {
     let defaultChatModels: Model[] = [];
 
     data.models.forEach((m: any) => {
-      if (m.supportedGenerationMethods.includes('embedText')) {
+      if (m.supportedGenerationMethods.some((genMethod: string) => genMethod === 'embedText' || genMethod === 'embedContent')) {
         defaultEmbeddingModels.push({
           key: m.name,
           name: m.displayName,


### PR DESCRIPTION
the new settings window does not list all available gemini embedding models. this happens because some gemini embedding models have `embedContent` instead of `embedText`