### PR TITLE
feat: add host network mode for better localhost integration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,9 @@
 services:
   perplexica:
     image: itzcrazykns1337/perplexica:latest
-    ports:
-      - '3000:3000'
+    network_mode: host
+    environment:
+      - HOSTNAME=0.0.0.0
     volumes:
       - data:/home/perplexica/data
       - uploads:/home/perplexica/uploads


### PR DESCRIPTION
## Summary

This PR updates the `docker-compose.yaml` to use host network mode, which significantly improves localhost integration for users running local LLM services like Ollama.

## Changes

- Switched from bridge to host network mode
- Added `HOSTNAME=0.0.0.0` environment variable for proper binding
- Removed port mapping (not needed with host network mode)

## Problem Solved

When running Perplexica in Docker with local Ollama instances, users face connectivity issues:
- On Linux, need to use host IP addresses instead of `localhost`
- Connection errors when trying to use `http://localhost:11434`
- Complicated setup with bridge network IPs

## Solution

Host network mode allows the container to use the host's network stack directly:
- `localhost` works seamlessly from inside the container
- No need for `host.docker.internal` or manual IP configuration
- Simpler setup for local LLM integrations

## Testing

Tested with:
- Dual Ollama setup (GPU on port 11434, CPU on port 11435)
- Perplexica successfully connects to both via `http://localhost:11434` and `http://localhost:11435`
- Web interface accessible at `http://localhost:3000`

## Platform Compatibility

**Note:** Host network mode is Linux-specific. Windows and Mac users should continue using the default bridge network configuration with appropriate host URLs (`host.docker.internal` or IP addresses).

## Benefits

- ✅ Simplified configuration for Linux users
- ✅ Better localhost service integration
- ✅ No complex network troubleshooting
- ✅ Maintains existing `restart: unless-stopped` policy