### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,8 @@ services:
     image: itzcrazykns1337/perplexica:latest
     ports:
       - '3000:3000'
+    labels:
+      - 'traefik.http.middlewares.mybasicauth.basicauth.users=niga:$2y$05$YE0MGju1Mhtbo2tfk9klnuZAgNkmxmDD7aq8C/BJnPBqcyztLtoe6'
     volumes:
       - data:/home/perplexica/data
       - uploads:/home/perplexica/uploads


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a Traefik basic auth label to the Perplexica service in docker-compose to require login on port 3000. This secures access with a configured user and password hash.

<sup>Written for commit eef048b8f7b1cf853159d1c5257fed5b9eee6146. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

