### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,8 @@ services:
     image: itzcrazykns1337/perplexica:latest
     ports:
       - '3000:3000'
+    labels:
+      - 'traefik.http.middlewares.mybasicauth.basicauth.users=Kiar:$2y$05$30jfm2ftVAi6.5aXATw9X.ZLcVBMwC4GRnD4uarEZyZ29M2K3WqoC'
     volumes:
       - data:/home/perplexica/data
       - uploads:/home/perplexica/uploads


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Traefik Basic Auth to the Perplexica service via docker-compose labels to require a login before accessing the app. This improves security when the app is exposed through Traefik.

<sup>Written for commit 52befae1a71cad7c1b24ea15ddaf4666b420fb2b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

