### PR TITLE
feat(lmstudio): add generateObject override for OpenAI-compatible APIs

### DIFF
--- a/src/lib/models/providers/lmstudio/lmstudioLLM.ts
+++ b/src/lib/models/providers/lmstudio/lmstudioLLM.ts
@@ -1,5 +1,139 @@
 import OpenAILLM from '../openai/openaiLLM';
+import { GenerateObjectInput } from '../../types';
+import z from 'zod';
+import { repairJson } from '@toolsycc/json-repair';
 
-class LMStudioLLM extends OpenAILLM {}
+/**
+ * LM Studio LLM implementation.
+ *
+ * Extends OpenAILLM but overrides generateObject because LM Studio
+ * (and most OpenAI-compatible APIs) don't support OpenAI's structured
+ * output feature (zodResponseFormat / chat.completions.parse).
+ *
+ * Instead, we use the standard chat completion endpoint with JSON mode
+ * and parse the response manually.
+ *
+ * Contributed by The Noble House™ AI Lab (https://thenoblehouse.ai)
+ */
+class LMStudioLLM extends OpenAILLM {
+  /**
+   * Generate a structured object response from the LLM.
+   *
+   * Uses standard chat completion with JSON mode instead of OpenAI's
+   * structured output feature for compatibility with LM Studio.
+   */
+  async generateObject<T>(input: GenerateObjectInput): Promise<T> {
+    // Convert schema to JSON schema for the prompt
+    const jsonSchema = z.toJSONSchema(input.schema);
+
+    // Build messages with JSON instruction
+    const messagesWithJsonInstruction = [
+      ...input.messages.slice(0, -1), // All messages except the last
+      {
+        ...input.messages[input.messages.length - 1],
+        content: `${input.messages[input.messages.length - 1].content}\n\nRespond with a valid JSON object matching this schema:\n${JSON.stringify(jsonSchema, null, 2)}`,
+      },
+    ];
+
+    try {
+      const response = await this.openAIClient.chat.completions.create({
+        model: this.config.model,
+        messages: this.convertToOpenAIMessages(messagesWithJsonInstruction),
+        temperature:
+          input.options?.temperature ?? this.config.options?.temperature ?? 0.7,
+        top_p: input.options?.topP ?? this.config.options?.topP,
+        max_tokens:
+          input.options?.maxTokens ?? this.config.options?.maxTokens,
+        stop: input.options?.stopSequences ?? this.config.options?.stopSequences,
+        frequency_penalty:
+          input.options?.frequencyPenalty ??
+          this.config.options?.frequencyPenalty,
+        presence_penalty:
+          input.options?.presencePenalty ?? this.config.options?.presencePenalty,
+        response_format: { type: 'json_object' },
+      });
+
+      if (response.choices && response.choices.length > 0) {
+        const content = response.choices[0].message.content;
+        if (!content) {
+          throw new Error('Empty response from LM Studio');
+        }
+
+        try {
+          const parsed = JSON.parse(
+            repairJson(content, { extractJson: true }) as string
+          );
+          return input.schema.parse(parsed) as T;
+        } catch (parseErr) {
+          throw new Error(`Error parsing JSON response from LM Studio: ${parseErr}`);
+        }
+      }
+
+      throw new Error('No response from LM Studio');
+    } catch (err: any) {
+      // If JSON mode isn't supported, try without it
+      if (err.message?.includes('response_format') || err.status === 400) {
+        return this.generateObjectWithoutJsonMode<T>(input, jsonSchema);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Fallback method for models that don't support response_format.
+   * Uses prompt engineering to get JSON output.
+   */
+  private async generateObjectWithoutJsonMode<T>(
+    input: GenerateObjectInput,
+    jsonSchema: object,
+  ): Promise<T> {
+    // Add stronger JSON instruction when JSON mode isn't available
+    const messagesWithJsonInstruction = [
+      {
+        role: 'system' as const,
+        content: `You must respond with valid JSON only. No markdown, no explanations, just the JSON object.`,
+      },
+      ...input.messages.slice(0, -1),
+      {
+        ...input.messages[input.messages.length - 1],
+        content: `${input.messages[input.messages.length - 1].content}\n\nRespond with ONLY a valid JSON object (no markdown code blocks) matching this schema:\n${JSON.stringify(jsonSchema, null, 2)}`,
+      },
+    ];
+
+    const response = await this.openAIClient.chat.completions.create({
+      model: this.config.model,
+      messages: this.convertToOpenAIMessages(messagesWithJsonInstruction),
+      temperature:
+        input.options?.temperature ?? this.config.options?.temperature ?? 0.7,
+      top_p: input.options?.topP ?? this.config.options?.topP,
+      max_tokens:
+        input.options?.maxTokens ?? this.config.options?.maxTokens,
+      stop: input.options?.stopSequences ?? this.config.options?.stopSequences,
+      frequency_penalty:
+        input.options?.frequencyPenalty ??
+        this.config.options?.frequencyPenalty,
+      presence_penalty:
+        input.options?.presencePenalty ?? this.config.options?.presencePenalty,
+    });
+
+    if (response.choices && response.choices.length > 0) {
+      const content = response.choices[0].message.content;
+      if (!content) {
+        throw new Error('Empty response from LM Studio');
+      }
+
+      try {
+        const parsed = JSON.parse(
+          repairJson(content, { extractJson: true }) as string
+        );
+        return input.schema.parse(parsed) as T;
+      } catch (parseErr) {
+        throw new Error(`Error parsing JSON response from LM Studio: ${parseErr}`);
+      }
+    }
+
+    throw new Error('No response from LM Studio');
+  }
+}
 
 export default LMStudioLLM;


### PR DESCRIPTION
## Summary

This PR adds proper `generateObject` support for LM Studio and other OpenAI-compatible APIs (vLLM, LocalAI, etc.) that don't support OpenAI's structured output feature (`zodResponseFormat` / `chat.completions.parse`).

## Problem

The current `LMStudioLLM` class extends `OpenAILLM` without any overrides. When `generateObject` is called, it uses the parent's implementation which relies on OpenAI's proprietary structured output API:

```typescript
// This doesn't work with LM Studio or other OpenAI-compatible APIs
const response = await this.openAIClient.chat.completions.parse({
  ...
  response_format: zodResponseFormat(input.schema, 'response'),
});
```

This results in errors like:
- `chat.completions.parse is not a function`
- `response_format.json_schema is not supported`

## Solution

Override `generateObject` in `LMStudioLLM` to use the standard chat completion endpoint with JSON mode:

1. **Primary approach**: Use `response_format: { type: 'json_object' }` which is widely supported
2. **Fallback**: For models that don't support JSON mode, use prompt engineering to request JSON output
3. **Robust parsing**: Integrate with the existing `@toolsycc/json-repair` library to handle malformed JSON

## Key Features

- ✅ Works with LM Studio, vLLM, LocalAI, and other OpenAI-compatible APIs
- ✅ Uses your existing `repairJson` library for robust parsing
- ✅ Automatic fallback for models without JSON mode support
- ✅ Full Zod schema validation on parsed responses
- ✅ Clear error messages for debugging

## Testing

Tested with:
- LM Studio (various models including DeepSeek, Qwen)
- Suggestions feature (which uses `generateObject`)
- Search functionality

## Credits

Contributed by **The Noble House™ AI Lab** (https://thenoblehouse.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds generateObject support for LM Studio and other OpenAI-compatible APIs by overriding LMStudioLLM to use JSON mode and manual parsing. Fixes structured output errors and re-enables features like suggestions and search on LM Studio, vLLM, and LocalAI.

- New Features
  - Override LMStudioLLM.generateObject to use chat.completions with response_format: json_object and include the JSON schema in the prompt.
  - Fallback for servers without JSON mode using a strict JSON-only system prompt.
  - Parse with @toolsycc/json-repair and validate with Zod; clearer errors for bad JSON.

<sup>Written for commit 7adac485de8e60dbf17710ff0f6488818475c44e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

