### PR TITLE
Add typing_extensions to searxng venv to fix build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN git clone "https://github.com/searxng/searxng" \
                    "/usr/local/searxng/searxng-src"
 
 RUN python3 -m venv "/usr/local/searxng/searx-pyenv"
-RUN "/usr/local/searxng/searx-pyenv/bin/pip" install --upgrade pip setuptools wheel pyyaml msgspec
+RUN "/usr/local/searxng/searx-pyenv/bin/pip" install --upgrade pip setuptools wheel pyyaml msgspec typing_extensions
 RUN cd "/usr/local/searxng/searxng-src" && \
     "/usr/local/searxng/searx-pyenv/bin/pip" install --use-pep517 --no-build-isolation -e .
 


### PR DESCRIPTION
Docker build failed with error as below due to missing typing_extensions in searxng venv. Updated Dockerfile to include this.

```
#35 [stage-1 21/26] RUN cd "/usr/local/searxng/searxng-src" &&     "/usr/local/searxng/searx-pyenv/bin/pip" install --use-pep517 --no-build-isolation -e .
#35 0.345 Obtaining file:///usr/local/searxng/searxng-src
#35 0.346   Checking if build backend supports build_editable: started
#35 0.423   Checking if build backend supports build_editable: finished with status 'done'
#35 0.424   Preparing editable metadata (pyproject.toml): started
#35 0.521   Preparing editable metadata (pyproject.toml): finished with status 'error'
#35 0.523   error: subprocess-exited-with-error
#35 0.523   
#35 0.523   × Preparing editable metadata (pyproject.toml) did not run successfully.
#35 0.523   │ exit code: 1
#35 0.523   ╰─> [26 lines of output]
#35 0.523       Traceback (most recent call last):
#35 0.523         File "/usr/local/searxng/searx-pyenv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in 
#35 0.523           main()
#35 0.523         File "/usr/local/searxng/searx-pyenv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
#35 0.523           json_out["return_val"] = hook(**hook_input["kwargs"])
#35 0.523                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#35 0.523         File "/usr/local/searxng/searx-pyenv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 209, in prepare_metadata_for_build_editable
#35 0.523           return hook(metadata_directory, config_settings)
#35 0.523                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#35 0.523         File "/usr/local/searxng/searx-pyenv/lib/python3.11/site-packages/setuptools/build_meta.py", line 484, in prepare_metadata_for_build_editable
#35 0.523           return self.prepare_metadata_for_build_wheel(
#35 0.523                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#35 0.523         File "/usr/local/searxng/searx-pyenv/lib/python3.11/site-packages/setuptools/build_meta.py", line 378, in prepare_metadata_for_build_wheel
#35 0.523           self.run_setup()
#35 0.523         File "/usr/local/searxng/searx-pyenv/lib/python3.11/site-packages/setuptools/build_meta.py", line 518, in run_setup
#35 0.523           super().run_setup(setup_script=setup_script)
#35 0.523         File "/usr/local/searxng/searx-pyenv/lib/python3.11/site-packages/setuptools/build_meta.py", line 317, in run_setup
#35 0.523           exec(code, locals())
#35 0.523         File "", line 6, in 
#35 0.523         File "/usr/local/searxng/searxng-src/searx/__init__.py", line 139, in 
#35 0.523           init_settings()
#35 0.523         File "/usr/local/searxng/searxng-src/searx/__init__.py", line 39, in init_settings
#35 0.523           from searx.settings_defaults import SCHEMA, apply_schema
#35 0.523         File "/usr/local/searxng/searxng-src/searx/settings_defaults.py", line 15, in 
#35 0.523           from typing_extensions import override
#35 0.523       ModuleNotFoundError: No module named 'typing_extensions'
#35 0.523       [end of output]
#35 0.523   
#35 0.523   note: This error originates from a subprocess, and is likely not a problem with pip.
#35 0.626 error: metadata-generation-failed
#35 0.626 
#35 0.626 × Encountered error while generating package metadata.
#35 0.626 ╰─> from file:///usr/local/searxng/searxng-src
#35 0.626 
#35 0.626 note: This is an issue with the package mentioned above, not pip.
#35 0.626 hint: See above for details.
#35 ERROR: process "/bin/sh -c cd \"/usr/local/searxng/searxng-src\" &&     \"/usr/local/searxng/searx-pyenv/bin/pip\" install --use-pep517 --no-build-isolation -e ." did not complete successfully: exit code: 1
------
 > [stage-1 21/26] RUN cd "/usr/local/searxng/searxng-src" &&     "/usr/local/searxng/searx-pyenv/bin/pip" install --use-pep517 --no-build-isolation -e .:
0.523       [end of output]
0.523   
0.523   note: This error originates from a subprocess, and is likely not a problem with pip.
0.626 error: metadata-generation-failed
0.626 
0.626 × Encountered error while generating package metadata.
0.626 ╰─> from file:///usr/local/searxng/searxng-src
0.626 
0.626 note: This is an issue with the package mentioned above, not pip.
0.626 hint: See above for details.
------
Dockerfile:58
--------------------
  57 |     RUN "/usr/local/searxng/searx-pyenv/bin/pip" install --upgrade pip setuptools wheel pyyaml msgspec
  58 | >>> RUN cd "/usr/local/searxng/searxng-src" && \
  59 | >>>     "/usr/local/searxng/searx-pyenv/bin/pip" install --use-pep517 --no-build-isolation -e .
  60 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cd \"/usr/local/searxng/searxng-src\" &&     \"/usr/local/searxng/searx-pyenv/bin/pip\" install --use-pep517 --no-build-isolation -e ." did not complete successfully: exit code: 1
```