### PR TITLE
perplexica update

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,70 @@
 services:
+  # Perplexica
   perplexica:
-    image: itzcrazykns1337/perplexica:latest
+    image: itzcrazykns1337/perplexica:main
+    build:
+      context: .
+      dockerfile: app.dockerfile
+    container_name: perplexica
     ports:
-      - '3000:3000'
+      - 3000:3000
+    environment:
+      - SEARXNG_API_URL=http://searxng:8080
+      - OLLAMA_API_URL=http://127.0.0.1:11434
+      - DATA_DIR=/home/perplexica
+    depends_on:
+      - searxng
+      - ollama
+    networks:
+      - ai_network
     volumes:
-      - data:/home/perplexica/data
+      - backend-dbstore:/home/perplexica/data
       - uploads:/home/perplexica/uploads
+      - ./config.toml:/home/perplexica/config.toml
+    restart: unless-stopped
+
+
+
+  # SearXNG
+  searxng:
+    image: docker.io/searxng/searxng:latest
+    # container_name: searxng
+    ports:
+      - 4000:8080
+    volumes:
+      - ./searxng:/etc/searxng:rw
+    networks:
+      - ai_network
+    restart: unless-stopped
+
+  # Ollama
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    ports:
+      - 11434:11434
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      - OLLAMA_HOST=0.0.0.0:11434
+      - OLLAMA_ORIGINS=http://localhost,https://localhost,http://127.0.0.1,https://127.0.0.1,http://0.0.0.0,https://0.0.0.0
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            capabilities: ["gpu"]
+            count: all  # Adjust count for the number of GPUs you want to use
+    networks:
+      - ai_network
     restart: unless-stopped
 
 volumes:
-  data:
-    name: 'perplexica-data'
+  ollama_data:
+  backend-dbstore:
   uploads:
-    name: 'perplexica-uploads'
+
+networks:
+  ai_network:
+    driver: bridge
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add SearXNG and Ollama to the docker-compose stack and wire Perplexica to them for local search and model inference. Adds a dedicated network, GPU support, and clearer volumes/config mounts.

- New Features
  - Added searxng (port 4000) and ollama (port 11434) services on a shared ai_network.
  - Perplexica now uses SEARXNG_API_URL and OLLAMA_API_URL; mounts config.toml; updated volumes.
  - Enabled NVIDIA GPU passthrough for Ollama.
  - Switched Perplexica image tag to main and added local build context; set restart policies.

- Migration
  - Replace volume "data" with "backend-dbstore"; keep "uploads" as-is.
  - Ensure ./searxng directory and config.toml exist before deploy.
  - If no NVIDIA GPU, remove the Ollama deploy.resources block.
  - Access SearXNG at localhost:4000; Perplexica reaches it internally at searxng:8080.

<sup>Written for commit 28f2a4507567e77d921eda9eb9abfc53492a2c00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

