### PR TITLE
fix: add typing_extensions to searxng venv in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN git clone "https://github.com/searxng/searxng" \
                    "/usr/local/searxng/searxng-src"
 
 RUN python3 -m venv "/usr/local/searxng/searx-pyenv"
-RUN "/usr/local/searxng/searx-pyenv/bin/pip" install --upgrade pip setuptools wheel pyyaml msgspec
+RUN "/usr/local/searxng/searx-pyenv/bin/pip" install --upgrade pip setuptools wheel pyyaml msgspec typing_extensions
 RUN cd "/usr/local/searxng/searxng-src" && \
     "/usr/local/searxng/searx-pyenv/bin/pip" install --use-pep517 --no-build-isolation -e .
 


### PR DESCRIPTION
Fixes #985

## Summary

Fixes Docker build failure caused by missing `typing_extensions` dependency
when installing SearXNG.

## Problem

Docker build fails with error:

```
ModuleNotFoundError: No module named 'typing_extensions'
```

SearXNG requires `typing_extensions` as a dependency (it's imported in
`searx/settings_defaults.py`), but it was not being installed in the searxng
virtual environment before attempting to install SearXNG itself.

## Solution

Add `typing_extensions` to the list of packages installed in the searxng
virtual environment **before** installing SearXNG.

## Changes

**File: `Dockerfile` (line 57)**

```diff
-RUN "/usr/local/searxng/searx-pyenv/bin/pip" install --upgrade pip setuptools wheel pyyaml msgspec
+RUN "/usr/local/searxng/searx-pyenv/bin/pip" install --upgrade pip setuptools wheel pyyaml msgspec typing_extensions
```

## Impact

- ✅ **Fixes**: Docker build failure for all users
- ✅ **Low Risk**: Only adds a missing dependency that SearXNG explicitly requires
- ✅ **No Breaking Changes**: Existing functionality is preserved

## Testing

Docker build now completes successfully without the `typing_extensions` error.

---

**Full Error Before Fix:**
```
error: subprocess-exited-with-error
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  ╰─> from searx.settings_defaults import SCHEMA, apply_schema
      from typing_extensions import override
ModuleNotFoundError: No module named 'typing_extensions'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker build failure by installing typing_extensions in the SearXNG venv before installing SearXNG (fixes #985). Restores successful builds and aligns the image with SearXNG’s required dependencies.

<sup>Written for commit 3315406a2253bde2513bf5911fd11ea92af37e60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

