### PR TITLE
Attempt fix: #973 Perplexica does not consult Web search

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -210,20 +210,27 @@ export const POST = async (req: Request) => {
       }
     });
 
-    agent.searchAsync(session, {
-      chatHistory: history,
-      followUp: message.content,
-      chatId: body.message.chatId,
-      messageId: body.message.messageId,
-      config: {
-        llm,
-        embedding: embedding,
-        sources: body.sources as SearchSources[],
-        mode: body.optimizationMode,
-        fileIds: body.files,
-        systemInstructions: body.systemInstructions || 'None',
-      },
-    });
+    agent
+      .searchAsync(session, {
+        chatHistory: history,
+        followUp: message.content,
+        chatId: body.message.chatId,
+        messageId: body.message.messageId,
+        config: {
+          llm,
+          embedding: embedding,
+          sources: body.sources as SearchSources[],
+          mode: body.optimizationMode,
+          fileIds: body.files,
+          systemInstructions: body.systemInstructions || 'None',
+        },
+      })
+      .catch((error) => {
+        console.error('Search agent failed:', error);
+        session.emit('error', {
+          data: 'Failed to complete web-assisted response.',
+        });
+      });
 
     ensureChatExists({
       id: body.message.chatId,

--- a/src/lib/agents/search/classifier.ts
+++ b/src/lib/agents/search/classifier.ts
@@ -34,6 +34,21 @@ const schema = z.object({
     ),
 });
 
+const shouldForceWebSearch = (query: string) => {
+  const normalizedQuery = query.toLowerCase();
+
+  // Queries with strong recency cues should always consult search instead of
+  // relying on model pretraining knowledge.
+  return (
+    /\b(current|latest|today|yesterday|tomorrow|recent|newest|breaking|now)\b/.test(
+      normalizedQuery,
+    ) ||
+    /\bthis\s+(week|month|year)\b/.test(normalizedQuery) ||
+    /\bas of\b/.test(normalizedQuery) ||
+    /\b20\d{2}\b/.test(normalizedQuery)
+  );
+};
+
 export const classify = async (input: ClassifierInput) => {
   const output = await input.llm.generateObject<typeof schema>({
     messages: [
@@ -48,6 +63,18 @@ export const classify = async (input: ClassifierInput) => {
     ],
     schema,
   });
+
+  const isWidgetOnlyQuery =
+    output.classification.showWeatherWidget ||
+    output.classification.showStockWidget ||
+    output.classification.showCalculationWidget;
+
+  if (
+    !isWidgetOnlyQuery &&
+    shouldForceWebSearch(output.standaloneFollowUp || input.query)
+  ) {
+    output.classification.skipSearch = false;
+  }
 
   return output;
 };


### PR DESCRIPTION
Automated first-pass attempt for issue #973.

Issue: https://github.com/ItzCrazyKns/Perplexica/issues/973
Estimated LOC target: 15-45

This is a draft PR for maintainer review and iteration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #973 by ensuring web search is used for time‑sensitive queries and by surfacing search failures to the session. This improves answer freshness and prevents silent failures.

- **Bug Fixes**
  - Force web search when queries include recency cues (e.g., “today,” “latest,” “as of,” specific years), unless a widget-only query.
  - Catch and log search agent errors and emit a session error message to avoid unhandled rejections.

<sup>Written for commit 14e170a4814d7028e6af52d2b9c7309f2c82ea89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

