### PR TITLE
feat: Adding Minimax coding API as a provider.

### DIFF
--- a/src/lib/models/providers/index.ts
+++ b/src/lib/models/providers/index.ts
@@ -8,6 +8,7 @@ import GroqProvider from './groq';
 import LemonadeProvider from './lemonade';
 import AnthropicProvider from './anthropic';
 import LMStudioProvider from './lmstudio';
+import MinimaxProvider from './minimax';
 
 export const providers: Record<string, ProviderConstructor<any>> = {
   openai: OpenAIProvider,
@@ -18,6 +19,7 @@ export const providers: Record<string, ProviderConstructor<any>> = {
   lemonade: LemonadeProvider,
   anthropic: AnthropicProvider,
   lmstudio: LMStudioProvider,
+  minimax: MinimaxProvider,
 };
 
 export const getModelProvidersUIConfigSection =

--- a/src/lib/models/providers/minimax/index.ts
+++ b/src/lib/models/providers/minimax/index.ts
@@ -1,0 +1,96 @@
+import { UIConfigField } from '@/lib/config/types';
+import { Model, ModelList, ProviderMetadata } from '../../types';
+import BaseEmbedding from '../../base/embedding';
+import BaseModelProvider from '../../base/provider';
+import BaseLLM from '../../base/llm';
+import MinimaxLLM from './minimaxLLM';
+
+interface MinimaxConfig {
+  apiKey: string;
+}
+
+const providerConfigFields: UIConfigField[] = [
+  {
+    type: 'password',
+    name: 'API Key',
+    key: 'apiKey',
+    description: 'Your Minimax API key',
+    required: true,
+    placeholder: 'Minimax API Key',
+    env: 'MINIMAX_API_KEY',
+    scope: 'server',
+  },
+];
+
+class MinimaxProvider extends BaseModelProvider<MinimaxConfig> {
+  constructor(id: string, name: string, config: MinimaxConfig) {
+    super(id, name, config);
+  }
+
+  async getDefaultModels(): Promise<ModelList> {
+    const defaultChatModels: Model[] = [
+      { key: 'MiniMax-M2.5', name: 'MiniMax-M2.5' },
+      { key: 'MiniMax-M2.5-highspeed', name: 'MiniMax-M2.5-highspeed' },
+      { key: 'MiniMax-M2.1', name: 'MiniMax-M2.1' },
+      { key: 'MiniMax-M2.1-highspeed', name: 'MiniMax-M2.1-highspeed' },
+      { key: 'MiniMax-M2', name: 'MiniMax-M2' },
+    ];
+
+    return {
+      embedding: [],
+      chat: defaultChatModels,
+    };
+  }
+
+  async getModelList(): Promise<ModelList> {
+    return this.getDefaultModels();
+  }
+
+  async loadChatModel(key: string): Promise<BaseLLM<any>> {
+    const modelList = await this.getModelList();
+
+    const exists = modelList.chat.find((m) => m.key === key);
+
+    if (!exists) {
+      throw new Error(
+        'Error Loading Minimax Chat Model. Invalid Model Selected',
+      );
+    }
+
+    return new MinimaxLLM({
+      apiKey: this.config.apiKey,
+      model: key,
+      baseURL: 'https://api.minimax.io/v1',
+    });
+  }
+
+  async loadEmbeddingModel(
+    key: string,
+  ): Promise<BaseEmbedding<any>> {
+    throw new Error('Minimax Provider does not support embedding models.');
+  }
+
+  static parseAndValidate(raw: any): MinimaxConfig {
+    if (!raw || typeof raw !== 'object')
+      throw new Error('Invalid config provided. Expected object');
+    if (!raw.apiKey)
+      throw new Error('Invalid config provided. API key must be provided');
+
+    return {
+      apiKey: String(raw.apiKey),
+    };
+  }
+
+  static getProviderConfigFields(): UIConfigField[] {
+    return providerConfigFields;
+  }
+
+  static getProviderMetadata(): ProviderMetadata {
+    return {
+      key: 'minimax',
+      name: 'Minimax',
+    };
+  }
+}
+
+export default MinimaxProvider;

--- a/src/lib/models/providers/minimax/minimaxLLM.ts
+++ b/src/lib/models/providers/minimax/minimaxLLM.ts
@@ -1,0 +1,94 @@
+import OpenAILLM from '../openai/openaiLLM';
+import { zodResponseFormat } from 'openai/helpers/zod';
+import { GenerateObjectInput } from '../../types';
+import { repairJson } from '@toolsycc/json-repair';
+
+/**
+ * MinimaxLLM extends OpenAILLM to add MiniMax-specific handling.
+ * 
+ * MiniMax models (M2, M2.1, M2.5) support thinking/reasoning that gets
+ * embedded in the content field as <thinking> tags when using the OpenAI-compatible
+ * API. This breaks JSON parsing in generateObject() calls.
+ * 
+ * The fix is to add reasoning_split: true to the API call, which separates
+ * thinking into a separate reasoning_details field.
+ * 
+ * See: https://platform.minimax.io/docs/api-reference/text-openai-api.md
+ */
+
+/**
+ * Extract JSON from text by cleaning thinking/markdown and finding JSON boundaries
+ */
+function extractJSON(text: string): string {
+  // 1. Remove all thinking blocks (including multiline content)
+  let cleanedText = text.replace(/<minimax:[a-zA-Z0-9_-]+>[\s\S]*?<\/minimax:[a-zA-Z0-9_-]+>/gi, '');
+  cleanedText = cleanedText.replace(/<think>[\s\S]*?<\/think>/gi, '');
+  
+  // 2. Remove ONLY the markdown wrappers, not the content inside them!
+  cleanedText = cleanedText.replace(/```json/gi, '');
+  cleanedText = cleanedText.replace(/```/g, '');
+  
+  // 3. Find the boundaries of the actual JSON object
+  const startIndex = cleanedText.indexOf('{');
+  const endIndex = cleanedText.lastIndexOf('}');
+  
+  // 4. Extract and return only the JSON payload
+  if (startIndex !== -1 && endIndex !== -1 && endIndex >= startIndex) {
+    return cleanedText.substring(startIndex, endIndex + 1);
+  }
+  
+  // Fallback
+  return text;
+}
+
+class MinimaxLLM extends OpenAILLM {
+  async generateObject<T>(input: GenerateObjectInput): Promise<T> {
+    // CHANGE #1: Use .create() instead of .parse()
+    const response = await this.openAIClient.chat.completions.create({
+      messages: this.convertToOpenAIMessages(input.messages),
+      model: this.config.model,
+      temperature:
+        input.options?.temperature ?? this.config.options?.temperature ?? 1.0,
+      top_p: input.options?.topP ?? this.config.options?.topP,
+      max_completion_tokens:
+        input.options?.maxTokens ?? this.config.options?.maxTokens,
+      stop: input.options?.stopSequences ?? this.config.options?.stopSequences,
+      frequency_penalty:
+        input.options?.frequencyPenalty ??
+        this.config.options?.frequencyPenalty,
+      presence_penalty:
+        input.options?.presencePenalty ?? this.config.options?.presencePenalty,
+      // CHANGE #2: We keep response_format as json_object to hint to the model, 
+      // but without .parse(), the SDK won't try to auto-parse the result.
+      response_format: { type: 'json_object' },
+      // MiniMax-specific: split reasoning into separate field to prevent
+      // <thinking> tags from breaking JSON parsing
+      reasoning_split: true,
+    } as any); // Type cast might be needed depending on your OpenAI SDK version for custom params
+
+    if (response.choices && response.choices.length > 0) {
+      try {
+        const content = response.choices[0].message.content || '';
+        
+        // NOW your extraction logic will actually run!
+        const jsonStr = extractJSON(content);
+        
+        // Use repairJson as safety net
+        const repaired = repairJson(jsonStr, { extractJson: true });
+        if (!repaired) {
+          throw new Error('No valid JSON found in response');
+        }
+        
+        return input.schema.parse(
+          JSON.parse(repaired as string),
+        ) as T;
+      } catch (err) {
+        throw new Error(`Error parsing response from Minimax: ${err}`);
+      }
+    }
+
+    throw new Error('No response from Minimax');
+  }
+}
+
+export default MinimaxLLM;


### PR DESCRIPTION
I was unable to use the openai compatible provider because it requires split thinking parameter. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Minimax as a new provider and fix JSON parsing for MiniMax thinking models by splitting reasoning content from responses. This lets M2/M2.1/M2.5 models work with generateObject without parse errors.

- **New Features**
  - New Minimax provider with API key config (env: MINIMAX_API_KEY).
  - Supports chat models: MiniMax-M2, M2.1, M2.1-highspeed, M2.5, M2.5-highspeed.
  - Registered under minimax in the providers list; base URL https://api.minimax.io/v1.
  - Embeddings not supported.

- **Bug Fixes**
  - Overrode generateObject to use chat.completions.create with reasoning_split: true and response_format: json_object.
  - Strips thinking tags and markdown wrappers, then extracts and repairs JSON for reliable parsing.

<sup>Written for commit 0f1b37d7a047ebb01b8dca5d73657edc819dd2c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

