### PR TITLE
feat(providers): add Venice.ai as a model provider

### DIFF
--- a/src/lib/models/providers/index.ts
+++ b/src/lib/models/providers/index.ts
@@ -8,6 +8,7 @@ import GroqProvider from './groq';
 import LemonadeProvider from './lemonade';
 import AnthropicProvider from './anthropic';
 import LMStudioProvider from './lmstudio';
+import VeniceProvider from './venice';
 
 export const providers: Record<string, ProviderConstructor<any>> = {
   openai: OpenAIProvider,
@@ -18,6 +19,7 @@ export const providers: Record<string, ProviderConstructor<any>> = {
   lemonade: LemonadeProvider,
   anthropic: AnthropicProvider,
   lmstudio: LMStudioProvider,
+  venice: VeniceProvider,
 };
 
 export const getModelProvidersUIConfigSection =

--- a/src/lib/models/providers/venice/index.ts
+++ b/src/lib/models/providers/venice/index.ts
@@ -1,0 +1,117 @@
+import { UIConfigField } from '@/lib/config/types';
+import { getConfiguredModelProviderById } from '@/lib/config/serverRegistry';
+import { Model, ModelList, ProviderMetadata } from '../../types';
+import BaseEmbedding from '../../base/embedding';
+import BaseModelProvider from '../../base/provider';
+import BaseLLM from '../../base/llm';
+import VeniceLLM from './veniceLLM';
+
+interface VeniceConfig {
+  apiKey: string;
+}
+
+const providerConfigFields: UIConfigField[] = [
+  {
+    type: 'password',
+    name: 'API Key',
+    key: 'apiKey',
+    description: 'Your Venice.ai API key',
+    required: true,
+    placeholder: 'Venice API Key',
+    env: 'VENICE_API_KEY',
+    scope: 'server',
+  },
+];
+
+class VeniceProvider extends BaseModelProvider<VeniceConfig> {
+  constructor(id: string, name: string, config: VeniceConfig) {
+    super(id, name, config);
+  }
+
+  async getDefaultModels(): Promise<ModelList> {
+    const res = await fetch('https://api.venice.ai/api/v1/models', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+    });
+
+    const data = await res.json();
+
+    const defaultChatModels: Model[] = [];
+
+    data.data.forEach((m: any) => {
+      if (m.type === 'text' || !m.type) {
+        defaultChatModels.push({
+          key: m.id,
+          name: m.id,
+        });
+      }
+    });
+
+    return {
+      embedding: [],
+      chat: defaultChatModels,
+    };
+  }
+
+  async getModelList(): Promise<ModelList> {
+    const defaultModels = await this.getDefaultModels();
+    const configProvider = getConfiguredModelProviderById(this.id)!;
+
+    return {
+      embedding: [
+        ...defaultModels.embedding,
+        ...configProvider.embeddingModels,
+      ],
+      chat: [...defaultModels.chat, ...configProvider.chatModels],
+    };
+  }
+
+  async loadChatModel(key: string): Promise<BaseLLM<any>> {
+    const modelList = await this.getModelList();
+
+    const exists = modelList.chat.find((m) => m.key === key);
+
+    if (!exists) {
+      throw new Error(
+        'Error Loading Venice Chat Model. Invalid Model Selected',
+      );
+    }
+
+    return new VeniceLLM({
+      apiKey: this.config.apiKey,
+      model: key,
+      baseURL: 'https://api.venice.ai/api/v1',
+    });
+  }
+
+  async loadEmbeddingModel(key: string): Promise<BaseEmbedding<any>> {
+    throw new Error('Venice Provider does not support embedding models.');
+  }
+
+  static parseAndValidate(raw: any): VeniceConfig {
+    if (!raw || typeof raw !== 'object')
+      throw new Error('Invalid config provided. Expected object');
+    if (!raw.apiKey)
+      throw new Error('Invalid config provided. API key must be provided');
+
+    return {
+      apiKey: String(raw.apiKey),
+    };
+  }
+
+  static getProviderConfigFields(): UIConfigField[] {
+    return providerConfigFields;
+  }
+
+  static getProviderMetadata(): ProviderMetadata {
+    return {
+      key: 'venice',
+      name: 'Venice',
+    };
+  }
+}
+
+export default VeniceProvider;

--- a/src/lib/models/providers/venice/veniceLLM.ts
+++ b/src/lib/models/providers/venice/veniceLLM.ts
@@ -1,0 +1,38 @@
+import OpenAI from 'openai';
+import OpenAILLM from '../openai/openaiLLM';
+import { GenerateOptions } from '../../types';
+
+type VeniceLLMConfig = {
+  apiKey: string;
+  model: string;
+  baseURL?: string;
+  options?: GenerateOptions;
+};
+
+class VeniceLLM extends OpenAILLM {
+  constructor(config: VeniceLLMConfig) {
+    super(config);
+
+    this.openAIClient = new OpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseURL || 'https://api.venice.ai/api/v1',
+      fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.body && typeof init.body === 'string') {
+          try {
+            const body = JSON.parse(init.body);
+            body.venice_parameters = {
+              enable_web_search: 'off',
+              include_venice_system_prompt: false,
+            };
+            init = { ...init, body: JSON.stringify(body) };
+          } catch {
+            /* body isn't JSON, pass through unchanged */
+          }
+        }
+        return globalThis.fetch(url, init);
+      },
+    });
+  }
+}
+
+export default VeniceLLM;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Venice.ai as a model provider using its OpenAI‑compatible API. Enables selecting Venice chat models while keeping our own search and system prompt behavior.

- New Features
  - New provider "Venice" (key: venice) with base URL https://api.venice.ai/api/v1
  - Models fetched dynamically from Venice and exposed as chat models
  - VeniceLLM extends OpenAILLM and injects venice_parameters to disable web search and Venice’s system prompt

- Migration
  - Set VENICE_API_KEY on the server or in provider settings
  - Select the Venice provider and choose a model
  - Note: embeddings are not supported yet

<sup>Written for commit 9883d35728e8e4fe593e0fa676b356eb86b857ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

