### PR TITLE
feat: add Novita AI as optional LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Want to know more about its architecture and how it works? You can read it [here
 
 ## ✨ Features
 
-🤖 **Support for all major AI providers** - Use local LLMs through Ollama or connect to OpenAI, Anthropic Claude, Google Gemini, Groq, and more. Mix and match models based on your needs.
+🤖 **Support for all major AI providers** - Use local LLMs through Ollama or connect to OpenAI, Anthropic Claude, Google Gemini, Groq, Novita AI, and more. Mix and match models based on your needs.
 
 ⚡ **Smart search modes** - Choose Speed Mode when you need quick answers, Balanced Mode for everyday searches, or Quality Mode for deep research.
 

--- a/src/lib/models/providers/index.ts
+++ b/src/lib/models/providers/index.ts
@@ -8,6 +8,7 @@ import GroqProvider from './groq';
 import LemonadeProvider from './lemonade';
 import AnthropicProvider from './anthropic';
 import LMStudioProvider from './lmstudio';
+import NovitaProvider from './novita';
 
 export const providers: Record<string, ProviderConstructor<any>> = {
   openai: OpenAIProvider,
@@ -18,6 +19,7 @@ export const providers: Record<string, ProviderConstructor<any>> = {
   lemonade: LemonadeProvider,
   anthropic: AnthropicProvider,
   lmstudio: LMStudioProvider,
+  novita: NovitaProvider,
 };
 
 export const getModelProvidersUIConfigSection =

--- a/src/lib/models/providers/novita/index.ts
+++ b/src/lib/models/providers/novita/index.ts
@@ -1,0 +1,131 @@
+import { UIConfigField } from '@/lib/config/types';
+import { getConfiguredModelProviderById } from '@/lib/config/serverRegistry';
+import { Model, ModelList, ProviderMetadata } from '../../types';
+import BaseEmbedding from '../../base/embedding';
+import BaseModelProvider from '../../base/provider';
+import BaseLLM from '../../base/llm';
+import NovitaLLM from './novitaLLM';
+import NovitaEmbedding from './novitaEmbedding';
+
+interface NovitaConfig {
+  apiKey: string;
+}
+
+const providerConfigFields: UIConfigField[] = [
+  {
+    type: 'password',
+    name: 'API Key',
+    key: 'apiKey',
+    description: 'Your Novita AI API key',
+    required: true,
+    placeholder: 'Novita AI API Key',
+    env: 'NOVITA_API_KEY',
+    scope: 'server',
+  },
+];
+
+class NovitaProvider extends BaseModelProvider<NovitaConfig> {
+  constructor(id: string, name: string, config: NovitaConfig) {
+    super(id, name, config);
+  }
+
+  async getDefaultModels(): Promise<ModelList> {
+    const res = await fetch(`https://api.novita.ai/openai/models`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+    });
+
+    const data = await res.json();
+
+    const defaultChatModels: Model[] = [];
+
+    if (data.data && Array.isArray(data.data)) {
+      data.data.forEach((m: any) => {
+        defaultChatModels.push({
+          key: m.id,
+          name: m.id,
+        });
+      });
+    }
+
+    return {
+      embedding: [],
+      chat: defaultChatModels,
+    };
+  }
+
+  async getModelList(): Promise<ModelList> {
+    const defaultModels = await this.getDefaultModels();
+    const configProvider = getConfiguredModelProviderById(this.id)!;
+
+    return {
+      embedding: [
+        ...defaultModels.embedding,
+        ...configProvider.embeddingModels,
+      ],
+      chat: [...defaultModels.chat, ...configProvider.chatModels],
+    };
+  }
+
+  async loadChatModel(key: string): Promise<BaseLLM<any>> {
+    const modelList = await this.getModelList();
+
+    const exists = modelList.chat.find((m) => m.key === key);
+
+    if (!exists) {
+      throw new Error(
+        'Error Loading Novita Chat Model. Invalid Model Selected',
+      );
+    }
+
+    return new NovitaLLM({
+      apiKey: this.config.apiKey,
+      model: key,
+      baseURL: 'https://api.novita.ai/openai',
+    });
+  }
+
+  async loadEmbeddingModel(key: string): Promise<BaseEmbedding<any>> {
+    const modelList = await this.getModelList();
+    const exists = modelList.embedding.find((m) => m.key === key);
+
+    if (!exists) {
+      throw new Error(
+        'Error Loading Novita Embedding Model. Invalid Model Selected.',
+      );
+    }
+
+    return new NovitaEmbedding({
+      apiKey: this.config.apiKey,
+      model: key,
+      baseURL: 'https://api.novita.ai/openai',
+    });
+  }
+
+  static parseAndValidate(raw: any): NovitaConfig {
+    if (!raw || typeof raw !== 'object')
+      throw new Error('Invalid config provided. Expected object');
+    if (!raw.apiKey)
+      throw new Error('Invalid config provided. API key must be provided');
+
+    return {
+      apiKey: String(raw.apiKey),
+    };
+  }
+
+  static getProviderConfigFields(): UIConfigField[] {
+    return providerConfigFields;
+  }
+
+  static getProviderMetadata(): ProviderMetadata {
+    return {
+      key: 'novita',
+      name: 'Novita AI',
+    };
+  }
+}
+
+export default NovitaProvider;

--- a/src/lib/models/providers/novita/novitaEmbedding.ts
+++ b/src/lib/models/providers/novita/novitaEmbedding.ts
@@ -1,0 +1,5 @@
+import OpenAIEmbedding from '../openai/openaiEmbedding';
+
+class NovitaEmbedding extends OpenAIEmbedding {}
+
+export default NovitaEmbedding;

--- a/src/lib/models/providers/novita/novitaLLM.ts
+++ b/src/lib/models/providers/novita/novitaLLM.ts
@@ -1,0 +1,5 @@
+import OpenAILLM from '../openai/openaiLLM';
+
+class NovitaLLM extends OpenAILLM {}
+
+export default NovitaLLM;


### PR DESCRIPTION
## What this PR does

Adds [Novita AI](https://novita.ai) as an optional, drop-in replacement for existing OpenAI-compatible providers.

**Usage:** Set `NOVITA_API_KEY` in your environment — the existing configuration is preserved and unchanged.

Novita provides an OpenAI-compatible API endpoint (`https://api.novita.ai/openai`) with cost-effective access to leading models including DeepSeek, Llama, and more.

## Changes

- Created `src/lib/models/providers/novita/` directory.
- Implemented `NovitaProvider`, `NovitaLLM`, and `NovitaEmbedding` using the OpenAI-compatible pattern.
- Registered `NovitaProvider` in `src/lib/models/providers/index.ts`.
- Updated `README.md` to include Novita AI in the list of supported providers.

<details>
<summary>Integration analysis</summary>

- **Architecture**: multi_provider
- **Pattern reference**: `src/lib/models/providers/groq/`
- **Deviations**: Added embedding support via `NovitaEmbedding` extending `OpenAIEmbedding`.

</details>

## Testing

Set `NOVITA_API_KEY=<your-key>` and you should be able to select Novita AI as a provider in the setup screen and use its models for both chat and embeddings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Novita AI as an optional, OpenAI-compatible provider for chat and embeddings. Enables using Novita models by setting NOVITA_API_KEY, with no other config changes.

- **New Features**
  - Added NovitaProvider with chat and embedding support via https://api.novita.ai/openai.
  - Registered provider in the models index and updated README.
  - Fetches model list from /openai/models for selection in the UI.

- **Migration**
  - Set NOVITA_API_KEY in the server environment.
  - Select Novita in the setup screen and choose models for chat and embeddings.

<sup>Written for commit 826e3637c42054caebe71dcc533cdad37c083e05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

