### PR TITLE
feat: Add DeepSeek AI provider support

### DIFF
--- a/src/lib/models/providers/deepseek/deepseekEmbedding.ts
+++ b/src/lib/models/providers/deepseek/deepseekEmbedding.ts
@@ -1,0 +1,41 @@
+import BaseEmbedding from '../../base/embedding';
+import OpenAI from 'openai';
+
+type DeepSeekEmbeddingConfig = {
+  apiKey: string;
+  model: string;
+  baseURL?: string;
+};
+
+class DeepSeekEmbedding extends BaseEmbedding<DeepSeekEmbeddingConfig> {
+  deepseekClient: OpenAI;
+
+  constructor(protected config: DeepSeekEmbeddingConfig) {
+    super(config);
+
+    this.deepseekClient = new OpenAI({
+      apiKey: this.config.apiKey,
+      baseURL: this.config.baseURL || 'https://api.deepseek.com/v1',
+    });
+  }
+
+  async embedDocuments(documents: string[]): Promise<number[][]> {
+    const response = await this.deepseekClient.embeddings.create({
+      model: this.config.model,
+      input: documents,
+    });
+
+    return response.data.map((item) => item.embedding);
+  }
+
+  async embedQuery(document: string): Promise<number[]> {
+    const response = await this.deepseekClient.embeddings.create({
+      model: this.config.model,
+      input: [document],
+    });
+
+    return response.data[0].embedding;
+  }
+}
+
+export default DeepSeekEmbedding;

--- a/src/lib/models/providers/deepseek/deepseekLLM.ts
+++ b/src/lib/models/providers/deepseek/deepseekLLM.ts
@@ -1,0 +1,228 @@
+import OpenAI from 'openai';
+import BaseLLM from '../../base/llm';
+import { zodTextFormat, zodResponseFormat } from 'openai/helpers/zod';
+import {
+  GenerateObjectInput,
+  GenerateTextInput,
+  GenerateTextOutput,
+  StreamTextOutput,
+  ToolCall,
+} from '../../types';
+import { parse } from 'partial-json';
+import z from 'zod';
+import {
+  ChatCompletionAssistantMessageParam,
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+  ChatCompletionToolMessageParam,
+} from 'openai/resources/index.mjs';
+import { Message } from '@/lib/types';
+import { repairJson } from '@toolsycc/json-repair';
+
+type DeepSeekConfig = {
+  apiKey: string;
+  model: string;
+  baseURL?: string;
+};
+
+class DeepSeekLLM extends BaseLLM<DeepSeekConfig> {
+  deepseekClient: OpenAI;
+
+  constructor(protected config: DeepSeekConfig) {
+    super(config);
+
+    this.deepseekClient = new OpenAI({
+      apiKey: this.config.apiKey,
+      baseURL: this.config.baseURL || 'https://api.deepseek.com/v1',
+    });
+  }
+
+  convertToDeepSeekMessages(messages: Message[]): ChatCompletionMessageParam[] {
+    return messages.map((msg) => {
+      if (msg.role === 'tool') {
+        return {
+          role: 'tool',
+          tool_call_id: msg.id,
+          content: msg.content,
+        } as ChatCompletionToolMessageParam;
+      } else if (msg.role === 'assistant') {
+        return {
+          role: 'assistant',
+          content: msg.content,
+          ...(msg.tool_calls &&
+            msg.tool_calls.length > 0 && {
+              tool_calls: msg.tool_calls?.map((tc) => ({
+                id: tc.id,
+                type: 'function',
+                function: {
+                  name: tc.name,
+                  arguments: JSON.stringify(tc.arguments),
+                },
+              })),
+            }),
+        } as ChatCompletionAssistantMessageParam;
+      }
+
+      return msg;
+    });
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextOutput> {
+    const deepseekTools: ChatCompletionTool[] = [];
+
+    input.tools?.forEach((tool) => {
+      deepseekTools.push({
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: z.toJSONSchema(tool.schema),
+        },
+      });
+    });
+
+    const response = await this.deepseekClient.chat.completions.create({
+      model: this.config.model,
+      tools: deepseekTools.length > 0 ? deepseekTools : undefined,
+      messages: this.convertToDeepSeekMessages(input.messages),
+      temperature: input.options?.temperature ?? 1.0,
+      top_p: input.options?.topP,
+      max_completion_tokens: input.options?.maxTokens,
+      stop: input.options?.stopSequences,
+      frequency_penalty: input.options?.frequencyPenalty,
+      presence_penalty: input.options?.presencePenalty,
+    });
+
+    if (response.choices && response.choices.length > 0) {
+      return {
+        content: response.choices[0].message.content!,
+        toolCalls:
+          response.choices[0].message.tool_calls
+            ?.map((tc) => {
+              if (tc.type === 'function') {
+                return {
+                  name: tc.function.name,
+                  id: tc.id,
+                  arguments: JSON.parse(tc.function.arguments),
+                };
+              }
+            })
+            .filter((tc) => tc !== undefined) || [],
+        additionalInfo: {
+          finishReason: response.choices[0].finish_reason,
+        },
+      };
+    }
+
+    throw new Error('No response from DeepSeek');
+  }
+
+  async *streamText(
+    input: GenerateTextInput,
+  ): AsyncGenerator<StreamTextOutput> {
+    const deepseekTools: ChatCompletionTool[] = [];
+
+    input.tools?.forEach((tool) => {
+      deepseekTools.push({
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: z.toJSONSchema(tool.schema),
+        },
+      });
+    });
+
+    const stream = await this.deepseekClient.chat.completions.create({
+      model: this.config.model,
+      messages: this.convertToDeepSeekMessages(input.messages),
+      tools: deepseekTools.length > 0 ? deepseekTools : undefined,
+      temperature: input.options?.temperature ?? 1.0,
+      top_p: input.options?.topP,
+      max_completion_tokens: input.options?.maxTokens,
+      stop: input.options?.stopSequences,
+      frequency_penalty: input.options?.frequencyPenalty,
+      presence_penalty: input.options?.presencePenalty,
+      stream: true,
+    });
+
+    let recievedToolCalls: { name: string; id: string; arguments: string }[] =
+      [];
+
+    for await (const chunk of stream) {
+      if (chunk.choices && chunk.choices.length > 0) {
+        const toolCalls = chunk.choices[0].delta.tool_calls;
+        yield {
+          contentChunk: chunk.choices[0].delta.content || '',
+          toolCallChunk:
+            toolCalls?.map((tc) => {
+              if (!recievedToolCalls[tc.index]) {
+                const call = {
+                  name: tc.function?.name!,
+                  id: tc.id!,
+                  arguments: tc.function?.arguments || '',
+                };
+                recievedToolCalls.push(call);
+                return { ...call, arguments: parse(call.arguments || '{}') };
+              } else {
+                const existingCall = recievedToolCalls[tc.index];
+                existingCall.arguments += tc.function?.arguments || '';
+                return {
+                  ...existingCall,
+                  arguments: parse(existingCall.arguments),
+                };
+              }
+            }) || [],
+          done: chunk.choices[0].finish_reason !== null,
+          additionalInfo: {
+            finishReason: chunk.choices[0].finish_reason,
+          },
+        };
+      }
+    }
+  }
+
+  async generateObject<T>(input: GenerateObjectInput): Promise<T> {
+    // DeepSeek doesn't support native JSON schema response format like OpenAI
+    // So we use the standard completion with a system prompt
+    const response = await this.deepseekClient.chat.completions.create({
+      messages: [
+        ...this.convertToDeepSeekMessages(input.messages),
+        {
+          role: 'system',
+          content: `You must respond with valid JSON that matches the following schema: ${JSON.stringify(z.toJSONSchema(input.schema))}. Do not include any markdown formatting, explanations, or extra text - only the raw JSON object.`,
+        },
+      ],
+      model: this.config.model,
+      temperature: input.options?.temperature ?? 1.0,
+      top_p: input.options?.topP,
+      max_completion_tokens: input.options?.maxTokens,
+      stop: input.options?.stopSequences,
+      frequency_penalty: input.options?.frequencyPenalty,
+      presence_penalty: input.options?.presencePenalty,
+    });
+
+    if (response.choices && response.choices.length > 0) {
+      try {
+        const content = response.choices[0].message.content!;
+        const repaired = repairJson(content, {
+          extractJson: true,
+        }) as string;
+        return input.schema.parse(JSON.parse(repaired)) as T;
+      } catch (err) {
+        throw new Error(`Error parsing response from DeepSeek: ${err}`);
+      }
+    }
+
+    throw new Error('No response from DeepSeek');
+  }
+
+  async *streamObject<T>(input: GenerateObjectInput): AsyncGenerator<T> {
+    // DeepSeek doesn't support native streaming JSON response format
+    // Fall back to non-streaming for object generation
+    const result = await this.generateObject<T>(input);
+    yield result;
+  }
+}
+
+export default DeepSeekLLM;

--- a/src/lib/models/providers/deepseek/index.ts
+++ b/src/lib/models/providers/deepseek/index.ts
@@ -1,0 +1,150 @@
+import { UIConfigField } from '@/lib/config/types';
+import { getConfiguredModelProviderById } from '@/lib/config/serverRegistry';
+import { Model, ModelList, ProviderMetadata } from '../../types';
+import DeepSeekEmbedding from './deepseekEmbedding';
+import BaseEmbedding from '../../base/embedding';
+import BaseModelProvider from '../../base/provider';
+import BaseLLM from '../../base/llm';
+import DeepSeekLLM from './deepseekLLM';
+
+interface DeepSeekConfig {
+  apiKey: string;
+  baseURL: string;
+}
+
+const defaultChatModels: Model[] = [
+  {
+    name: 'DeepSeek Chat',
+    key: 'deepseek-chat',
+  },
+  {
+    name: 'DeepSeek Reasoner',
+    key: 'deepseek-reasoner',
+  },
+];
+
+const defaultEmbeddingModels: Model[] = [
+  {
+    name: 'DeepSeek Embedding',
+    key: 'deepseek-embedding',
+  },
+];
+
+const providerConfigFields: UIConfigField[] = [
+  {
+    type: 'password',
+    name: 'API Key',
+    key: 'apiKey',
+    description: 'Your DeepSeek API key',
+    required: true,
+    placeholder: 'DeepSeek API Key',
+    env: 'DEEPSEEK_API_KEY',
+    scope: 'server',
+  },
+  {
+    type: 'string',
+    name: 'Base URL',
+    key: 'baseURL',
+    description: 'The base URL for the DeepSeek API',
+    required: true,
+    placeholder: 'DeepSeek Base URL',
+    default: 'https://api.deepseek.com/v1',
+    env: 'DEEPSEEK_BASE_URL',
+    scope: 'server',
+  },
+];
+
+class DeepSeekProvider extends BaseModelProvider<DeepSeekConfig> {
+  constructor(id: string, name: string, config: DeepSeekConfig) {
+    super(id, name, config);
+  }
+
+  async getDefaultModels(): Promise<ModelList> {
+    if (this.config.baseURL === 'https://api.deepseek.com/v1') {
+      return {
+        embedding: defaultEmbeddingModels,
+        chat: defaultChatModels,
+      };
+    }
+
+    return {
+      embedding: [],
+      chat: [],
+    };
+  }
+
+  async getModelList(): Promise<ModelList> {
+    const defaultModels = await this.getDefaultModels();
+    const configProvider = getConfiguredModelProviderById(this.id)!;
+
+    return {
+      embedding: [
+        ...defaultModels.embedding,
+        ...configProvider.embeddingModels,
+      ],
+      chat: [...defaultModels.chat, ...configProvider.chatModels],
+    };
+  }
+
+  async loadChatModel(key: string): Promise<BaseLLM<any>> {
+    const modelList = await this.getModelList();
+
+    const exists = modelList.chat.find((m) => m.key === key);
+
+    if (!exists) {
+      throw new Error(
+        'Error Loading DeepSeek Chat Model. Invalid Model Selected',
+      );
+    }
+
+    return new DeepSeekLLM({
+      apiKey: this.config.apiKey,
+      model: key,
+      baseURL: this.config.baseURL,
+    });
+  }
+
+  async loadEmbeddingModel(key: string): Promise<BaseEmbedding<any>> {
+    const modelList = await this.getModelList();
+    const exists = modelList.embedding.find((m) => m.key === key);
+
+    if (!exists) {
+      throw new Error(
+        'Error Loading DeepSeek Embedding Model. Invalid Model Selected.',
+      );
+    }
+
+    return new DeepSeekEmbedding({
+      apiKey: this.config.apiKey,
+      model: key,
+      baseURL: this.config.baseURL,
+    });
+  }
+
+  static parseAndValidate(raw: any): DeepSeekConfig {
+    if (!raw || typeof raw !== 'object')
+      throw new Error('Invalid config provided. Expected object');
+    if (!raw.apiKey || !raw.baseURL)
+      throw new Error(
+        'Invalid config provided. API key and base URL must be provided',
+      );
+
+    return {
+      apiKey: String(raw.apiKey),
+      baseURL: String(raw.baseURL),
+    };
+  }
+
+  static getProviderConfigFields(): UIConfigField[] {
+    return providerConfigFields;
+  }
+
+  static getProviderMetadata(): ProviderMetadata {
+    return {
+      key: 'deepseek',
+      name: 'DeepSeek',
+    };
+  }
+}
+
+export default DeepSeekProvider;

--- a/src/lib/models/providers/index.ts
+++ b/src/lib/models/providers/index.ts
@@ -8,6 +8,7 @@ import GroqProvider from './groq';
 import LemonadeProvider from './lemonade';
 import AnthropicProvider from './anthropic';
 import LMStudioProvider from './lmstudio';
+import DeepSeekProvider from './deepseek';
 
 export const providers: Record<string, ProviderConstructor<any>> = {
   openai: OpenAIProvider,
@@ -18,6 +19,7 @@ export const providers: Record<string, ProviderConstructor<any>> = {
   lemonade: LemonadeProvider,
   anthropic: AnthropicProvider,
   lmstudio: LMStudioProvider,
+  deepseek: DeepSeekProvider,
 };
 
 export const getModelProvidersUIConfigSection =


### PR DESCRIPTION
This PR adds DeepSeek as a new model provider option for Perplexica.

## Changes
- Added full LLM implementation with streaming support
- Added embedding model support for document search
- Default models: deepseek-chat and deepseek-reasoner
- OpenAI-compatible API integration
- Configuration fields for API key and base URL

## Why DeepSeek?
DeepSeek provides high-quality language models at competitive pricing with strong performance on various benchmarks.

## Testing
- Code follows existing provider patterns
- Includes proper TypeScript types
- Error handling implemented

Fixes #XXX (if there's a related issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added DeepSeek as a new model provider for chat and embeddings using an OpenAI-compatible API. Supports streaming and tool calls with default models deepseek-chat, deepseek-reasoner, and deepseek-embedding.

- **New Features**
  - Chat LLM with streaming responses and tool call support.
  - Embeddings for documents and queries.
  - Provider config fields: apiKey and baseURL (default https://api.deepseek.com/v1).
  - Registered provider and exposed default models.

- **Migration**
  - Set DEEPSEEK_API_KEY and optionally DEEPSEEK_BASE_URL.
  - Select DeepSeek models in settings; no code changes needed.

<sup>Written for commit 16df10ea50e9aa15d48c018492f01354a17f2f25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

