### PR TITLE
fix(UI): prevent search triggering on IME composition Enter key press

### DIFF
--- a/src/components/EmptyChatMessageInput.tsx
+++ b/src/components/EmptyChatMessageInput.tsx
@@ -14,6 +14,8 @@ const EmptyChatMessageInput = () => {
   const [message, setMessage] = useState('');
 
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const isComposing = useRef(false);
+  const lastCompositionEndTime = useRef(0);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -46,13 +48,6 @@ const EmptyChatMessageInput = () => {
         sendMessage(message);
         setMessage('');
       }}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-          e.preventDefault();
-          sendMessage(message);
-          setMessage('');
-        }
-      }}
       className="w-full"
     >
       <div className="flex flex-col bg-light-secondary dark:bg-dark-secondary px-3 pt-5 pb-3 rounded-2xl w-full border border-light-200 dark:border-dark-200 shadow-sm shadow-light-200/10 dark:shadow-black/20 transition-all duration-200 focus-within:border-light-300 dark:focus-within:border-dark-300">
@@ -61,6 +56,27 @@ const EmptyChatMessageInput = () => {
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           minRows={2}
+          onKeyDown={(e) => {
+            if (
+              e.key === 'Enter' &&
+              !e.shiftKey &&
+              !e.nativeEvent.isComposing &&
+              !isComposing.current &&
+              e.keyCode !== 229 &&
+              Date.now() - lastCompositionEndTime.current > 150
+            ) {
+              e.preventDefault();
+              sendMessage(message);
+              setMessage('');
+            }
+          }}
+          onCompositionStart={() => {
+            isComposing.current = true;
+          }}
+          onCompositionEnd={() => {
+            isComposing.current = false;
+            lastCompositionEndTime.current = Date.now();
+          }}
           className="px-2 bg-transparent placeholder:text-[15px] placeholder:text-black/50 dark:placeholder:text-white/50 text-sm text-black dark:text-white resize-none focus:outline-none w-full max-h-24 lg:max-h-36 xl:max-h-48"
           placeholder="Ask anything..."
         />

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -13,6 +13,9 @@ const MessageInput = () => {
   const [textareaRows, setTextareaRows] = useState(1);
   const [mode, setMode] = useState<'multi' | 'single'>('single');
 
+  const isComposing = useRef(false);
+  const lastCompositionEndTime = useRef(0);
+
   useEffect(() => {
     if (textareaRows >= 2 && message && mode === 'single') {
       setMode('multi');
@@ -53,13 +56,6 @@ const MessageInput = () => {
         sendMessage(message);
         setMessage('');
       }}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' && !e.shiftKey && !loading && !e.nativeEvent.isComposing) {
-          e.preventDefault();
-          sendMessage(message);
-          setMessage('');
-        }
-      }}
       className={cn(
         'relative bg-light-secondary dark:bg-dark-secondary p-4 flex items-center overflow-visible border border-light-200 dark:border-dark-200 shadow-sm shadow-light-200/10 dark:shadow-black/20 transition-all duration-200 focus-within:border-light-300 dark:focus-within:border-dark-300',
         mode === 'multi' ? 'flex-col rounded-2xl' : 'flex-row rounded-full',
@@ -72,6 +68,28 @@ const MessageInput = () => {
         onChange={(e) => setMessage(e.target.value)}
         onHeightChange={(height, props) => {
           setTextareaRows(Math.ceil(height / props.rowHeight));
+        }}
+        onKeyDown={(e) => {
+          if (
+            e.key === 'Enter' &&
+            !e.shiftKey &&
+            !loading &&
+            !e.nativeEvent.isComposing &&
+            !isComposing.current &&
+            e.keyCode !== 229 &&
+            Date.now() - lastCompositionEndTime.current > 150
+          ) {
+            e.preventDefault();
+            sendMessage(message);
+            setMessage('');
+          }
+        }}
+        onCompositionStart={() => {
+          isComposing.current = true;
+        }}
+        onCompositionEnd={() => {
+          isComposing.current = false;
+          lastCompositionEndTime.current = Date.now();
         }}
         className="transition bg-transparent dark:placeholder:text-white/50 placeholder:text-sm text-sm dark:text-white resize-none focus:outline-none w-full px-2 max-h-24 lg:max-h-36 xl:max-h-48 flex-grow flex-shrink"
         placeholder="Ask a follow-up"


### PR DESCRIPTION
## Description
Currently, when a user typing in a language that uses an Input Method Editor (IME) — such as Japanese, Chinese, or Korean — presses the `Enter` key to confirm their text composition, it inadvertently triggers the `sendMessage` function. This results in the search being submitted prematurely before the user has finished typing their query.
This PR fixes this issue by adding a `!e.nativeEvent.isComposing` check to the `onKeyDown` handlers in both [EmptyChatMessageInput.tsx](cci:7://file:///Users/ryo/Git/perplexica/src/components/EmptyChatMessageInput.tsx:0:0-0:0) and [MessageInput.tsx](cci:7://file:///Users/ryo/Git/perplexica/src/components/MessageInput.tsx:0:0-0:0).
## Changes
- **src/components/EmptyChatMessageInput.tsx**: Added `!e.nativeEvent.isComposing` condition to the `Enter` key check.
- **src/components/MessageInput.tsx**: Added `!e.nativeEvent.isComposing` condition to the `Enter` key check.
## Testing
- Verified that pressing `Enter` to confirm IME text conversion does **not** trigger the search submission.
- Verified that pressing `Enter` continuously after the IME text conversion is finalized correctly triggers the search submission as intended.
- Verified that standard English input with `Enter` still works correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Enter from submitting during IME composition in EmptyChatMessageInput and MessageInput, so Japanese/Chinese/Korean input doesn’t send queries early. Added composition tracking and Safari-safe handling (ignore keyCode 229 and wait 150ms after composition end); Enter then submits, and Shift+Enter still inserts a newline.

<sup>Written for commit f16de623f52328e7b2d3c0ccb0eccde6cbf34760. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

