### PR TITLE
fix: strip markdown code block wrappers before JSON parsing

### DIFF
--- a/src/lib/models/providers/ollama/ollamaLLM.ts
+++ b/src/lib/models/providers/ollama/ollamaLLM.ts
@@ -13,6 +13,17 @@ import crypto from 'crypto';
 import { Message } from '@/lib/types';
 import { repairJson } from '@toolsycc/json-repair';
 
+/**
+ * Strip markdown code block wrappers from LLM responses.
+ * Some models (e.g. Claude via OpenAI-compatible proxies) wrap JSON output in
+ * markdown code blocks (```json ... ```), which causes JSON.parse to fail.
+ */
+function stripCodeBlockWrappers(text: string): string {
+  return text
+    .replace(/^```(?:json)?\s*\n?/i, '')
+    .replace(/\n?```\s*$/i, '');
+}
+
 type OllamaConfig = {
   baseURL: string;
   model: string;
@@ -208,9 +219,10 @@ class OllamaLLM extends BaseLLM<OllamaConfig> {
     try {
       return input.schema.parse(
         JSON.parse(
-          repairJson(response.message.content, {
-            extractJson: true,
-          }) as string,
+          repairJson(
+            stripCodeBlockWrappers(response.message.content),
+            { extractJson: true },
+          ) as string,
         ),
       ) as T;
     } catch (err) {

--- a/src/lib/models/providers/openai/openaiLLM.ts
+++ b/src/lib/models/providers/openai/openaiLLM.ts
@@ -20,6 +20,17 @@ import {
 import { Message } from '@/lib/types';
 import { repairJson } from '@toolsycc/json-repair';
 
+/**
+ * Strip markdown code block wrappers from LLM responses.
+ * Some models (e.g. Claude via OpenAI-compatible proxies) wrap JSON output in
+ * markdown code blocks (```json ... ```), which causes JSON.parse to fail.
+ */
+function stripCodeBlockWrappers(text: string): string {
+  return text
+    .replace(/^```(?:json)?\s*\n?/i, '')
+    .replace(/\n?```\s*$/i, '');
+}
+
 type OpenAIConfig = {
   apiKey: string;
   model: string;
@@ -216,9 +227,10 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
       try {
         return input.schema.parse(
           JSON.parse(
-            repairJson(response.choices[0].message.content!, {
-              extractJson: true,
-            }) as string,
+            repairJson(
+              stripCodeBlockWrappers(response.choices[0].message.content!),
+              { extractJson: true },
+            ) as string,
           ),
         ) as T;
       } catch (err) {
@@ -263,7 +275,7 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
         }
       } else if (chunk.type === 'response.output_text.done' && chunk.text) {
         try {
-          yield parse(chunk.text) as T;
+          yield parse(stripCodeBlockWrappers(chunk.text)) as T;
         } catch (err) {
           throw new Error(`Error parsing response from OpenAI: ${err}`);
         }


### PR DESCRIPTION
## Summary

Fixes #959

After the v1.12.0 migration from LangChain to Vercel AI SDK, Claude models (and potentially others) fail with `SyntaxError: Unexpected token` when accessed via OpenAI-compatible proxies like LiteLLM or OpenRouter. The root cause is that these models wrap JSON output in markdown code blocks (` ```json ... ``` `), and `JSON.parse` cannot handle the wrapper.

## Changes

- Added `stripCodeBlockWrappers()` helper function to both `openaiLLM.ts` and `ollamaLLM.ts`
- Applied the function before `repairJson`/`JSON.parse` in `generateObject()` (both providers)
- Applied the function before `parse()` in `streamObject()` final chunk handling (OpenAI provider)
- The regex handles: ` ```json ... ``` `, ` ``` ... ``` `, and surrounding whitespace/newlines
- Since Anthropic, Gemini, Groq, Lemonade, and LM Studio providers all extend `OpenAILLM`, the fix covers all OpenAI-compatible providers automatically

## Why not just rely on `repairJson({ extractJson: true })`?

While `repairJson` with `extractJson: true` is already used, it doesn't reliably handle the markdown code block wrapper pattern (` ```json\n{...}\n``` `), as evidenced by the bug report. Adding explicit stripping before repair ensures robustness.

## Test plan

- [ ] Verify Claude models (e.g. `claude-haiku-4.5`) work via LiteLLM/OpenRouter without JSON parse errors
- [ ] Verify models that return raw JSON (e.g. Gemini, GPT) continue to work normally
- [ ] Verify Ollama models continue to work normally

**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSON parsing failures by stripping markdown code block fences from model responses before parsing. Prevents SyntaxError when Claude and other OpenAI-compatible providers return fenced JSON via proxies like LiteLLM or OpenRouter.

- **Bug Fixes**
  - Added `stripCodeBlockWrappers()` in `openaiLLM.ts` and `ollamaLLM.ts`.
  - Applied before `repairJson`/`JSON.parse` in `generateObject` (both providers).
  - Applied before `parse` for final text chunk in `streamObject` (OpenAI provider).
  - Handles ```json ... ``` and generic ``` ... ``` with optional whitespace.
  - Covers providers extending `OpenAILLM` (e.g., Anthropic, Gemini, Groq, Lemonade, LM Studio).
  - Continues to use `@toolsycc/json-repair` with `extractJson: true` for robustness.

<sup>Written for commit 49a5a74a024d66d570d957260d0078e1147c3460. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

