### PR TITLE
fix: guard against undefined .slice() calls in search actions

### DIFF
--- a/src/lib/agents/search/researcher/actions/academicSearch.ts
+++ b/src/lib/agents/search/researcher/actions/academicSearch.ts
@@ -30,7 +30,7 @@ const academicSearchAction: ResearchAction<typeof schema> = {
     config.classification.classification.skipSearch === false &&
     config.classification.classification.academicSearch === true,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    const queries = (input.queries ?? []).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,
@@ -40,7 +40,7 @@ const academicSearchAction: ResearchAction<typeof schema> = {
       researchBlock.data.subSteps.push({
         type: 'searching',
         id: crypto.randomUUID(),
-        searching: input.queries,
+        searching: queries,
       });
 
       additionalConfig.session.updateBlock(additionalConfig.researchBlockId, [
@@ -62,7 +62,7 @@ const academicSearchAction: ResearchAction<typeof schema> = {
         engines: ['arxiv', 'google scholar', 'pubmed'],
       });
 
-      const resultChunks: Chunk[] = res.results.map((r) => ({
+      const resultChunks: Chunk[] = (res.results ?? []).map((r) => ({
         content: r.content || r.title,
         metadata: {
           title: r.title,
@@ -117,7 +117,7 @@ const academicSearchAction: ResearchAction<typeof schema> = {
       }
     };
 
-    await Promise.all(input.queries.map(search));
+    await Promise.all(queries.map(search));
 
     return {
       type: 'search_results',

--- a/src/lib/agents/search/researcher/actions/scrapeURL.ts
+++ b/src/lib/agents/search/researcher/actions/scrapeURL.ts
@@ -25,7 +25,7 @@ const scrapeURLAction: ResearchAction<typeof schema> = {
   getDescription: () => actionDescription,
   enabled: (_) => true,
   execute: async (params, additionalConfig) => {
-    params.urls = params.urls.slice(0, 3);
+    const urls = (params.urls ?? []).slice(0, 3);
 
     let readingBlockId = crypto.randomUUID();
     let readingEmitted = false;
@@ -37,7 +37,7 @@ const scrapeURLAction: ResearchAction<typeof schema> = {
     const results: Chunk[] = [];
 
     await Promise.all(
-      params.urls.map(async (url) => {
+      urls.map(async (url) => {
         try {
           const res = await fetch(url);
           const text = await res.text();

--- a/src/lib/agents/search/researcher/actions/socialSearch.ts
+++ b/src/lib/agents/search/researcher/actions/socialSearch.ts
@@ -30,7 +30,7 @@ const socialSearchAction: ResearchAction<typeof schema> = {
     config.classification.classification.skipSearch === false &&
     config.classification.classification.discussionSearch === true,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    const queries = (input.queries ?? []).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,
@@ -40,7 +40,7 @@ const socialSearchAction: ResearchAction<typeof schema> = {
       researchBlock.data.subSteps.push({
         type: 'searching',
         id: crypto.randomUUID(),
-        searching: input.queries,
+        searching: queries,
       });
 
       additionalConfig.session.updateBlock(additionalConfig.researchBlockId, [
@@ -62,7 +62,7 @@ const socialSearchAction: ResearchAction<typeof schema> = {
         engines: ['reddit'],
       });
 
-      const resultChunks: Chunk[] = res.results.map((r) => ({
+      const resultChunks: Chunk[] = (res.results ?? []).map((r) => ({
         content: r.content || r.title,
         metadata: {
           title: r.title,
@@ -117,7 +117,7 @@ const socialSearchAction: ResearchAction<typeof schema> = {
       }
     };
 
-    await Promise.all(input.queries.map(search));
+    await Promise.all(queries.map(search));
 
     return {
       type: 'search_results',

--- a/src/lib/agents/search/researcher/actions/uploadsSearch.ts
+++ b/src/lib/agents/search/researcher/actions/uploadsSearch.ts
@@ -27,7 +27,7 @@ const uploadsSearchAction: ResearchAction<typeof schema> = {
   Never use this tool to search the web or for information that is not contained within the user's uploaded files.
   `,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    const queries = (input.queries ?? []).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,
@@ -37,7 +37,7 @@ const uploadsSearchAction: ResearchAction<typeof schema> = {
       researchBlock.data.subSteps.push({
         id: crypto.randomUUID(),
         type: 'upload_searching',
-        queries: input.queries,
+        queries: queries,
       });
 
       additionalConfig.session.updateBlock(additionalConfig.researchBlockId, [
@@ -54,7 +54,7 @@ const uploadsSearchAction: ResearchAction<typeof schema> = {
       fileIds: additionalConfig.fileIds,
     });
 
-    const results = await uploadStore.query(input.queries, 10);
+    const results = await uploadStore.query(queries, 10);
 
     const seenIds = new Map<string, number>();
 

--- a/src/lib/agents/search/researcher/actions/webSearch.ts
+++ b/src/lib/agents/search/researcher/actions/webSearch.ts
@@ -85,7 +85,7 @@ const webSearchAction: ResearchAction<typeof actionSchema> = {
     config.sources.includes('web') &&
     config.classification.classification.skipSearch === false,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    const queries = (input.queries ?? []).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,
@@ -95,7 +95,7 @@ const webSearchAction: ResearchAction<typeof actionSchema> = {
       researchBlock.data.subSteps.push({
         id: crypto.randomUUID(),
         type: 'searching',
-        searching: input.queries,
+        searching: queries,
       });
 
       additionalConfig.session.updateBlock(additionalConfig.researchBlockId, [
@@ -115,7 +115,7 @@ const webSearchAction: ResearchAction<typeof actionSchema> = {
     const search = async (q: string) => {
       const res = await searchSearxng(q);
 
-      const resultChunks: Chunk[] = res.results.map((r) => ({
+      const resultChunks: Chunk[] = (res.results ?? []).map((r) => ({
         content: r.content || r.title,
         metadata: {
           title: r.title,
@@ -170,7 +170,7 @@ const webSearchAction: ResearchAction<typeof actionSchema> = {
       }
     };
 
-    await Promise.all(input.queries.map(search));
+    await Promise.all(queries.map(search));
 
     return {
       type: 'search_results',

--- a/src/lib/searxng.ts
+++ b/src/lib/searxng.ts
@@ -41,8 +41,8 @@ export const searchSearxng = async (
   const res = await fetch(url);
   const data = await res.json();
 
-  const results: SearxngSearchResult[] = data.results;
-  const suggestions: string[] = data.suggestions;
+  const results: SearxngSearchResult[] = data.results ?? [];
+  const suggestions: string[] = data.suggestions ?? [];
 
   return { results, suggestions };
 };


### PR DESCRIPTION
## Summary

Fixes #964

Adds defensive null checks (`?? []`) before `.slice()` calls in the search execution pipeline to prevent `TypeError: Cannot read properties of undefined (reading 'slice')`.

The crash occurs when LLM tool call arguments arrive with `queries` or `urls` as `undefined` (common with LiteLLM proxies or models that don't perfectly conform to tool calling format), or when SearXNG returns an unexpected response shape without a `results` array.

## Changes

- **`webSearch.ts`**: Guard `input.queries` with `?? []` before `.slice(0, 3)`; guard `res.results` with `?? []` before `.map()`
- **`academicSearch.ts`**: Same guards for `input.queries` and `res.results`
- **`socialSearch.ts`**: Same guards for `input.queries` and `res.results`
- **`uploadsSearch.ts`**: Guard `input.queries` with `?? []` before `.slice(0, 3)`
- **`scrapeURL.ts`**: Guard `params.urls` with `?? []` before `.slice(0, 3)`
- **`searxng.ts`**: Guard `data.results` and `data.suggestions` with `?? []` at the source, preventing downstream crashes in all consumers

## Root cause

The error trace from the issue:
```
TypeError: Cannot read properties of undefined (reading 'slice')
    at Object.execute (.next/server/chunks/641.js:41:596)
    at d.execute (.next/server/chunks/641.js:123:140)
    at d.executeAll (.next/server/chunks/641.js:123:218)
    at i.research (.next/server/chunks/641.js:541:988)
```

This maps to:
1. `Object.execute` = action's `execute()` method calling `.slice()` on `input.queries`/`params.urls`
2. `d.execute` / `d.executeAll` = `ActionRegistry.execute()`/`executeAll()`
3. `i.research` = `Researcher.research()`

When LLM arguments are parsed from tool calls, the `queries`/`urls` fields can be `undefined` if the model response is malformed. Similarly, SearXNG can return responses without a `results` field.

## Test plan

- [ ] Search with a working SearXNG + standard LLM should still work normally
- [ ] Search with a model that returns malformed tool call arguments (e.g. via LiteLLM proxy) should gracefully return empty results instead of crashing
- [ ] Academic and social search modes should also be protected
- [ ] URL scraping with undefined urls should not crash

**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents search crashes by guarding `.slice()`/`.map()` calls when `queries`, `urls`, or SearXNG response fields are undefined. Fixes #964 so malformed tool-call arguments or empty SearXNG responses return empty results instead of throwing.

- **Bug Fixes**
  - Guard `input.queries` and `params.urls` with `?? []` before `.slice(0, 3)` in web, academic, social, and uploads search actions and URL scraping (use local `queries`/`urls` vars).
  - Default SearXNG `results` and `suggestions` to `[]`, and use `(res.results ?? [])` in actions before `.map()`.

<sup>Written for commit 345233409c5bbf0cbff4e85b7cfe890d1d79e970. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

