### PR TITLE
fix: handle missing opening <think> tag for deepseek-r1-671b

### DIFF
--- a/src/lib/hooks/useChat.tsx
+++ b/src/lib/hooks/useChat.tsx
@@ -1,847 +1,474 @@
-'use client';
-
-import { Message } from '@/components/ChatWindow';
-import { Block } from '@/lib/types';
+import { LanguageModelV4StreamPart, SharedV4Warning } from '@ai-sdk/provider';
 import {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import crypto from 'crypto';
-import { useParams, useSearchParams } from 'next/navigation';
-import { toast } from 'sonner';
-import { getSuggestions } from '../actions';
-import { MinimalProvider } from '../models/types';
-import { getAutoMediaSearch } from '../config/clientRegistry';
-import { applyPatch } from 'rfc6902';
-import { Widget } from '@/components/ChatWindow';
+  getErrorMessage,
+  IdGenerator,
+  ModelMessage,
+  SystemModelMessage,
+} from '@ai-sdk/provider-utils';
+import { Tracer } from '@opentelemetry/api';
+import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
+import { TelemetrySettings } from '../telemetry/telemetry-settings';
+import { FinishReason, LanguageModelUsage, ProviderMetadata } from '../types';
+import { Source } from '../types/language-model';
+import { asLanguageModelUsage } from '../types/usage';
+import { executeToolCall } from './execute-tool-call';
+import {
+  StreamTextOnToolCallFinishCallback,
+  StreamTextOnToolCallStartCallback,
+} from './stream-text';
+import { DefaultGeneratedFileWithType, GeneratedFile } from './generated-file';
+import { isApprovalNeeded } from './is-approval-needed';
+import { parseToolCall } from './parse-tool-call';
+import { ToolApprovalRequestOutput } from './tool-approval-request-output';
+import { TypedToolCall } from './tool-call';
+import { ToolCallRepairFunction } from './tool-call-repair-function';
+import { TypedToolError } from './tool-error';
+import { TypedToolResult } from './tool-result';
+import { ToolSet } from './tool-set';
 
-export type Section = {
-  message: Message;
-  widgets: Widget[];
-  parsedTextBlocks: string[];
-  speechMessage: string;
-  thinkingEnded: boolean;
-  suggestions?: string[];
-};
-
-type ChatContext = {
-  messages: Message[];
-  sections: Section[];
-  chatHistory: [string, string][];
-  files: File[];
-  fileIds: string[];
-  sources: string[];
-  chatId: string | undefined;
-  optimizationMode: string;
-  isMessagesLoaded: boolean;
-  loading: boolean;
-  notFound: boolean;
-  messageAppeared: boolean;
-  isReady: boolean;
-  hasError: boolean;
-  chatModelProvider: ChatModelProvider;
-  embeddingModelProvider: EmbeddingModelProvider;
-  researchEnded: boolean;
-  setResearchEnded: (ended: boolean) => void;
-  setOptimizationMode: (mode: string) => void;
-  setSources: (sources: string[]) => void;
-  setFiles: (files: File[]) => void;
-  setFileIds: (fileIds: string[]) => void;
-  sendMessage: (
-    message: string,
-    messageId?: string,
-    rewrite?: boolean,
-  ) => Promise<void>;
-  rewrite: (messageId: string) => void;
-  setChatModelProvider: (provider: ChatModelProvider) => void;
-  setEmbeddingModelProvider: (provider: EmbeddingModelProvider) => void;
-};
-
-export interface File {
-  fileName: string;
-  fileExtension: string;
-  fileId: string;
-}
-
-interface ChatModelProvider {
-  key: string;
-  providerId: string;
-}
-
-interface EmbeddingModelProvider {
-  key: string;
-  providerId: string;
-}
-
-const checkConfig = async (
-  setChatModelProvider: (provider: ChatModelProvider) => void,
-  setEmbeddingModelProvider: (provider: EmbeddingModelProvider) => void,
-  setIsConfigReady: (ready: boolean) => void,
-  setHasError: (hasError: boolean) => void,
-) => {
-  try {
-    let chatModelKey = localStorage.getItem('chatModelKey');
-    let chatModelProviderId = localStorage.getItem('chatModelProviderId');
-    let embeddingModelKey = localStorage.getItem('embeddingModelKey');
-    let embeddingModelProviderId = localStorage.getItem(
-      'embeddingModelProviderId',
-    );
-
-    const res = await fetch(`/api/providers`, {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (!res.ok) {
-      throw new Error(
-        `Provider fetching failed with status code ${res.status}`,
-      );
+export type SingleRequestTextStreamPart<TOOLS extends ToolSet> =
+  // Text blocks:
+  | {
+      type: 'text-start';
+      providerMetadata?: ProviderMetadata;
+      id: string;
+    }
+  | {
+      type: 'text-delta';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+      delta: string;
+    }
+  | {
+      type: 'text-end';
+      providerMetadata?: ProviderMetadata;
+      id: string;
     }
 
-    const data = await res.json();
-    const providers: MinimalProvider[] = data.providers;
-
-    if (providers.length === 0) {
-      throw new Error(
-        'No chat model providers found, please configure them in the settings page.',
-      );
+  // Reasoning blocks:
+  | {
+      type: 'reasoning-start';
+      providerMetadata?: ProviderMetadata;
+      id: string;
+    }
+  | {
+      type: 'reasoning-delta';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+      delta: string;
+    }
+  | {
+      type: 'reasoning-end';
+      id: string;
+      providerMetadata?: ProviderMetadata;
     }
 
-    const chatModelProvider =
-      providers.find((p) => p.id === chatModelProviderId) ??
-      providers.find((p) => p.chatModels.length > 0);
-
-    if (!chatModelProvider) {
-      throw new Error(
-        'No chat models found, pleae configure them in the settings page.',
-      );
+  // Tool calls:
+  | {
+      type: 'tool-input-start';
+      id: string;
+      toolName: string;
+      providerMetadata?: ProviderMetadata;
+      dynamic?: boolean;
+      title?: string;
     }
-
-    chatModelProviderId = chatModelProvider.id;
-
-    const chatModel =
-      chatModelProvider.chatModels.find((m) => m.key === chatModelKey) ??
-      chatModelProvider.chatModels[0];
-    chatModelKey = chatModel.key;
-
-    const embeddingModelProvider =
-      providers.find((p) => p.id === embeddingModelProviderId) ??
-      providers.find((p) => p.embeddingModels.length > 0);
-
-    if (!embeddingModelProvider) {
-      throw new Error(
-        'No embedding models found, pleae configure them in the settings page.',
-      );
+  | {
+      type: 'tool-input-delta';
+      id: string;
+      delta: string;
+      providerMetadata?: ProviderMetadata;
     }
+  | {
+      type: 'tool-input-end';
+      id: string;
+      providerMetadata?: ProviderMetadata;
+    }
+  | ToolApprovalRequestOutput<TOOLS>
 
-    embeddingModelProviderId = embeddingModelProvider.id;
+  // Other types:
+  | ({ type: 'source' } & Source)
+  | { type: 'file'; file: GeneratedFile; providerMetadata?: ProviderMetadata } // different because of GeneratedFile object
+  | ({ type: 'tool-call' } & TypedToolCall<TOOLS>)
+  | ({ type: 'tool-result' } & TypedToolResult<TOOLS>)
+  | ({ type: 'tool-error' } & TypedToolError<TOOLS>)
+  | { type: 'stream-start'; warnings: SharedV4Warning[] }
+  | {
+      type: 'response-metadata';
+      id?: string;
+      timestamp?: Date;
+      modelId?: string;
+    }
+  | {
+      type: 'finish';
+      finishReason: FinishReason;
+      rawFinishReason: string | undefined;
+      usage: LanguageModelUsage;
+      providerMetadata?: ProviderMetadata;
+    }
+  | { type: 'error'; error: unknown }
+  | { type: 'raw'; rawValue: unknown };
 
-    const embeddingModel =
-      embeddingModelProvider.embeddingModels.find(
-        (m) => m.key === embeddingModelKey,
-      ) ?? embeddingModelProvider.embeddingModels[0];
-    embeddingModelKey = embeddingModel.key;
-
-    localStorage.setItem('chatModelKey', chatModelKey);
-    localStorage.setItem('chatModelProviderId', chatModelProviderId);
-    localStorage.setItem('embeddingModelKey', embeddingModelKey);
-    localStorage.setItem('embeddingModelProviderId', embeddingModelProviderId);
-
-    setChatModelProvider({
-      key: chatModelKey,
-      providerId: chatModelProviderId,
-    });
-
-    setEmbeddingModelProvider({
-      key: embeddingModelKey,
-      providerId: embeddingModelProviderId,
-    });
-
-    setIsConfigReady(true);
-  } catch (err: any) {
-    console.error('An error occurred while checking the configuration:', err);
-    toast.error(err.message);
-    setIsConfigReady(false);
-    setHasError(true);
-  }
-};
-
-const loadMessages = async (
-  chatId: string,
-  setMessages: (messages: Message[]) => void,
-  setIsMessagesLoaded: (loaded: boolean) => void,
-  chatHistory: React.MutableRefObject<[string, string][]>,
-  setSources: (sources: string[]) => void,
-  setNotFound: (notFound: boolean) => void,
-  setFiles: (files: File[]) => void,
-  setFileIds: (fileIds: string[]) => void,
-) => {
-  const res = await fetch(`/api/chats/${chatId}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
+export function runToolsTransformation<TOOLS extends ToolSet>({
+  tools,
+  generatorStream,
+  tracer,
+  telemetry,
+  system,
+  messages,
+  abortSignal,
+  repairToolCall,
+  experimental_context,
+  generateId,
+  stepNumber,
+  model,
+  onToolCallStart,
+  onToolCallFinish,
+}: {
+  tools: TOOLS | undefined;
+  generatorStream: ReadableStream<LanguageModelV4StreamPart>;
+  tracer: Tracer;
+  telemetry: TelemetrySettings | undefined;
+  system: string | SystemModelMessage | Array<SystemModelMessage> | undefined;
+  messages: ModelMessage[];
+  abortSignal: AbortSignal | undefined;
+  repairToolCall: ToolCallRepairFunction<TOOLS> | undefined;
+  experimental_context: unknown;
+  generateId: IdGenerator;
+  stepNumber?: number;
+  model?: { provider: string; modelId: string };
+  onToolCallStart?:
+    | StreamTextOnToolCallStartCallback<TOOLS>
+    | Array<StreamTextOnToolCallStartCallback<TOOLS> | undefined | null>;
+  onToolCallFinish?:
+    | StreamTextOnToolCallFinishCallback<TOOLS>
+    | Array<StreamTextOnToolCallFinishCallback<TOOLS> | undefined | null>;
+}): ReadableStream<SingleRequestTextStreamPart<TOOLS>> {
+  // tool results stream
+  let toolResultsStreamController: ReadableStreamDefaultController<
+    SingleRequestTextStreamPart<TOOLS>
+  > | null = null;
+  let toolResultsStreamClosed = false;
+  const toolResultsStream = new ReadableStream<
+    SingleRequestTextStreamPart<TOOLS>
+  >({
+    start(controller) {
+      toolResultsStreamController = controller;
+    },
+    cancel() {
+      toolResultsStreamClosed = true;
     },
   });
 
-  if (res.status === 404) {
-    setNotFound(true);
-    setIsMessagesLoaded(true);
-    return;
-  }
-
-  const data = await res.json();
-
-  const messages = data.messages as Message[];
-
-  setMessages(messages);
-
-  const history: [string, string][] = [];
-  messages.forEach((msg) => {
-    history.push(['human', msg.query]);
-
-    const textBlocks = msg.responseBlocks
-      .filter(
-        (block): block is Block & { type: 'text' } => block.type === 'text',
-      )
-      .map((block) => block.data)
-      .join('\n');
-
-    if (textBlocks) {
-      history.push(['assistant', textBlocks]);
+  // Guard wrappers to prevent "Controller is already closed" crashes when
+  // the combined stream is terminated (e.g. LLM error) while tools are
+  // still executing asynchronously.
+  function safeEnqueue(chunk: SingleRequestTextStreamPart<TOOLS>) {
+    if (toolResultsStreamClosed) return;
+    try {
+      toolResultsStreamController!.enqueue(chunk);
+    } catch {
+      toolResultsStreamClosed = true;
     }
-  });
-
-  console.debug(new Date(), 'app:messages_loaded');
-
-  if (messages.length > 0) {
-    document.title = messages[0].query;
   }
 
-  const files = data.chat.files.map((file: any) => {
-    return {
-      fileName: file.name,
-      fileExtension: file.name.split('.').pop(),
-      fileId: file.fileId,
-    };
-  });
+  function safeClose() {
+    if (toolResultsStreamClosed) return;
+    try {
+      toolResultsStreamController!.close();
+      toolResultsStreamClosed = true;
+    } catch {
+      toolResultsStreamClosed = true;
+    }
+  }
 
-  setFiles(files);
-  setFileIds(files.map((file: File) => file.fileId));
+  // keep track of outstanding tool results for stream closing:
+  const outstandingToolResults = new Set<string>();
 
-  chatHistory.current = history;
-  setSources(data.chat.sources);
-  setIsMessagesLoaded(true);
-};
+  // keep track of tool inputs for provider-side tool results
+  const toolInputs = new Map<string, unknown>();
 
-export const chatContext = createContext<ChatContext>({
-  chatHistory: [],
-  chatId: '',
-  fileIds: [],
-  files: [],
-  sources: [],
-  hasError: false,
-  isMessagesLoaded: false,
-  isReady: false,
-  loading: false,
-  messageAppeared: false,
-  messages: [],
-  sections: [],
-  notFound: false,
-  optimizationMode: '',
-  chatModelProvider: { key: '', providerId: '' },
-  embeddingModelProvider: { key: '', providerId: '' },
-  researchEnded: false,
-  rewrite: () => {},
-  sendMessage: async () => {},
-  setFileIds: () => {},
-  setFiles: () => {},
-  setSources: () => {},
-  setOptimizationMode: () => {},
-  setChatModelProvider: () => {},
-  setEmbeddingModelProvider: () => {},
-  setResearchEnded: () => {},
-});
+  // keep track of parsed tool calls so provider-emitted approval requests can reference them
+  const toolCallsByToolCallId = new Map<string, TypedToolCall<TOOLS>>();
 
-export const ChatProvider = ({ children }: { children: React.ReactNode }) => {
-  const params: { chatId: string } = useParams();
+  let canClose = false;
+  let finishChunk:
+    | (SingleRequestTextStreamPart<TOOLS> & { type: 'finish' })
+    | undefined = undefined;
 
-  const searchParams = useSearchParams();
-  const initialMessage = searchParams.get('q');
-
-  const [chatId, setChatId] = useState<string | undefined>(params.chatId);
-  const [newChatCreated, setNewChatCreated] = useState(false);
-
-  const [loading, setLoading] = useState(false);
-  const [messageAppeared, setMessageAppeared] = useState(false);
-
-  const [researchEnded, setResearchEnded] = useState(false);
-
-  const chatHistory = useRef<[string, string][]>([]);
-  const [messages, setMessages] = useState<Message[]>([]);
-
-  const [files, setFiles] = useState<File[]>([]);
-  const [fileIds, setFileIds] = useState<string[]>([]);
-
-  const [sources, setSources] = useState<string[]>(['web']);
-  const [optimizationMode, setOptimizationMode] = useState('speed');
-
-  const [isMessagesLoaded, setIsMessagesLoaded] = useState(false);
-
-  const [notFound, setNotFound] = useState(false);
-
-  const [chatModelProvider, setChatModelProvider] = useState<ChatModelProvider>(
-    {
-      key: '',
-      providerId: '',
-    },
-  );
-
-  const [embeddingModelProvider, setEmbeddingModelProvider] =
-    useState<EmbeddingModelProvider>({
-      key: '',
-      providerId: '',
-    });
-
-  const [isConfigReady, setIsConfigReady] = useState(false);
-  const [hasError, setHasError] = useState(false);
-  const [isReady, setIsReady] = useState(false);
-
-  const messagesRef = useRef<Message[]>([]);
-
-  const sections = useMemo<Section[]>(() => {
-    return messages.map((msg) => {
-      const textBlocks: string[] = [];
-      let speechMessage = '';
-      let thinkingEnded = false;
-      let suggestions: string[] = [];
-
-      const sourceBlocks = msg.responseBlocks.filter(
-        (block): block is Block & { type: 'source' } => block.type === 'source',
-      );
-      const sources = sourceBlocks.flatMap((block) => block.data);
-
-      const widgetBlocks = msg.responseBlocks
-        .filter((b) => b.type === 'widget')
-        .map((b) => b.data) as Widget[];
-
-      msg.responseBlocks.forEach((block) => {
-        if (block.type === 'text') {
-          let processedText = block.data;
-          const citationRegex = /\[([^\]]+)\]/g;
-          const regex = /\[(\d+)\]/g;
-
-          if (processedText.includes('<think>')) {
-            const openThinkTag = processedText.match(/<think>/g)?.length || 0;
-            const closeThinkTag =
-              processedText.match(/<\/think>/g)?.length || 0;
-
-            if (openThinkTag && !closeThinkTag) {
-              processedText += '</think> <a> </a>';
-            }
-          }
-
-          if (block.data.includes('</think>')) {
-            thinkingEnded = true;
-          }
-
-          if (sources.length > 0) {
-            processedText = processedText.replace(
-              citationRegex,
-              (_, capturedContent: string) => {
-                const numbers = capturedContent
-                  .split(',')
-                  .map((numStr) => numStr.trim());
-
-                const linksHtml = numbers
-                  .map((numStr) => {
-                    const number = parseInt(numStr);
-
-                    if (isNaN(number) || number <= 0) {
-                      return `[${numStr}]`;
-                    }
-
-                    const source = sources[number - 1];
-                    const url = source?.metadata?.url;
-
-                    if (url) {
-                      return `<citation href="${url}">${numStr}</citation>`;
-                    } else {
-                      return ``;
-                    }
-                  })
-                  .join('');
-
-                return linksHtml;
-              },
-            );
-            speechMessage += block.data.replace(regex, '');
-          } else {
-            processedText = processedText.replace(regex, '');
-            speechMessage += block.data.replace(regex, '');
-          }
-
-          textBlocks.push(processedText);
-        } else if (block.type === 'suggestion') {
-          suggestions = block.data;
-        }
-      });
-
-      return {
-        message: msg,
-        parsedTextBlocks: textBlocks,
-        speechMessage,
-        thinkingEnded,
-        suggestions,
-        widgets: widgetBlocks,
-      };
-    });
-  }, [messages]);
-
-  const isReconnectingRef = useRef(false);
-  const handledMessageEndRef = useRef<Set<string>>(new Set());
-
-  const checkReconnect = async () => {
-    if (isReconnectingRef.current) return;
-
-    setIsReady(true);
-    console.debug(new Date(), 'app:ready');
-
-    if (messages.length > 0) {
-      const lastMsg = messages[messages.length - 1];
-
-      if (lastMsg.status === 'answering') {
-        setLoading(true);
-        setResearchEnded(false);
-        setMessageAppeared(false);
-
-        isReconnectingRef.current = true;
-
-        const res = await fetch(`/api/reconnect/${lastMsg.backendId}`, {
-          method: 'POST',
-        });
-
-        if (!res.body) throw new Error('No response body');
-
-        const reader = res.body?.getReader();
-        const decoder = new TextDecoder('utf-8');
-
-        let partialChunk = '';
-
-        const messageHandler = getMessageHandler(lastMsg);
-
-        try {
-          while (true) {
-            const { value, done } = await reader.read();
-            if (done) break;
-
-            partialChunk += decoder.decode(value, { stream: true });
-
-            try {
-              const messages = partialChunk.split('\n');
-              for (const msg of messages) {
-                if (!msg.trim()) continue;
-                const json = JSON.parse(msg);
-                messageHandler(json);
-              }
-              partialChunk = '';
-            } catch (error) {
-              console.warn('Incomplete JSON, waiting for next chunk...');
-            }
-          }
-        } finally {
-          isReconnectingRef.current = false;
-        }
+  function attemptClose() {
+    // close the tool results controller if no more outstanding tool calls
+    if (canClose && outstandingToolResults.size === 0) {
+      // we delay sending the finish chunk until all tool results (incl. delayed ones)
+      // are received to ensure that the frontend receives tool results before a message
+      // finish event arrives.
+      if (finishChunk != null) {
+        safeEnqueue(finishChunk);
       }
+
+      safeClose();
     }
-  };
+  }
 
-  useEffect(() => {
-    checkConfig(
-      setChatModelProvider,
-      setEmbeddingModelProvider,
-      setIsConfigReady,
-      setHasError,
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (params.chatId && params.chatId !== chatId) {
-      setChatId(params.chatId);
-      setMessages([]);
-      chatHistory.current = [];
-      setFiles([]);
-      setFileIds([]);
-      setIsMessagesLoaded(false);
-      setNotFound(false);
-      setNewChatCreated(false);
-    }
-  }, [params.chatId, chatId]);
-
-  useEffect(() => {
-    if (
-      chatId &&
-      !newChatCreated &&
-      !isMessagesLoaded &&
-      messages.length === 0
+  // forward stream
+  const forwardStream = new TransformStream<
+    LanguageModelV4StreamPart,
+    SingleRequestTextStreamPart<TOOLS>
+  >({
+    async transform(
+      chunk: LanguageModelV4StreamPart,
+      controller: TransformStreamDefaultController<
+        SingleRequestTextStreamPart<TOOLS>
+      >,
     ) {
-      loadMessages(
-        chatId,
-        setMessages,
-        setIsMessagesLoaded,
-        chatHistory,
-        setSources,
-        setNotFound,
-        setFiles,
-        setFileIds,
-      );
-    } else if (!chatId) {
-      setNewChatCreated(true);
-      setIsMessagesLoaded(true);
-      setChatId(crypto.randomBytes(20).toString('hex'));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatId, isMessagesLoaded, newChatCreated, messages.length]);
+      const chunkType = chunk.type;
 
-  useEffect(() => {
-    messagesRef.current = messages;
-  }, [messages]);
-
-  useEffect(() => {
-    if (isMessagesLoaded && isConfigReady && newChatCreated) {
-      setIsReady(true);
-      console.debug(new Date(), 'app:ready');
-    } else if (isMessagesLoaded && isConfigReady && !newChatCreated) {
-      checkReconnect();
-    } else {
-      setIsReady(false);
-    }
-  }, [isMessagesLoaded, isConfigReady, newChatCreated]);
-
-  const rewrite = (messageId: string) => {
-    const index = messages.findIndex((msg) => msg.messageId === messageId);
-
-    if (index === -1) return;
-
-    setMessages((prev) => prev.slice(0, index));
-
-    chatHistory.current = chatHistory.current.slice(0, index * 2);
-
-    const messageToRewrite = messages[index];
-    sendMessage(messageToRewrite.query, messageToRewrite.messageId, true);
-  };
-
-  useEffect(() => {
-    if (isReady && initialMessage && isConfigReady) {
-      if (!isConfigReady) {
-        toast.error('Cannot send message before the configuration is ready');
-        return;
-      }
-      sendMessage(initialMessage);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isConfigReady, isReady, initialMessage]);
-
-  const getMessageHandler = (message: Message) => {
-    const messageId = message.messageId;
-
-    return async (data: any) => {
-      if (data.type === 'error') {
-        toast.error(data.data);
-        setLoading(false);
-        setMessages((prev) =>
-          prev.map((msg) =>
-            msg.messageId === messageId
-              ? { ...msg, status: 'error' as const }
-              : msg,
-          ),
-        );
-        return;
-      }
-
-      if (data.type === 'researchComplete') {
-        setResearchEnded(true);
-        if (
-          message.responseBlocks.find(
-            (b) => b.type === 'source' && b.data.length > 0,
-          )
-        ) {
-          setMessageAppeared(true);
-        }
-      }
-
-      if (data.type === 'block') {
-        setMessages((prev) =>
-          prev.map((msg) => {
-            if (msg.messageId === messageId) {
-              const exists = msg.responseBlocks.findIndex(
-                (b) => b.id === data.block.id,
-              );
-
-              if (exists !== -1) {
-                const existingBlocks = [...msg.responseBlocks];
-                existingBlocks[exists] = data.block;
-
-                return {
-                  ...msg,
-                  responseBlocks: existingBlocks,
-                };
-              }
-
-              return {
-                ...msg,
-                responseBlocks: [...msg.responseBlocks, data.block],
-              };
-            }
-            return msg;
-          }),
-        );
-
-        if (
-          (data.block.type === 'source' && data.block.data.length > 0) ||
-          data.block.type === 'text'
-        ) {
-          setMessageAppeared(true);
-        }
-      }
-
-      if (data.type === 'updateBlock') {
-        setMessages((prev) =>
-          prev.map((msg) => {
-            if (msg.messageId === messageId) {
-              const updatedBlocks = msg.responseBlocks.map((block) => {
-                if (block.id === data.blockId) {
-                  const updatedBlock = { ...block };
-                  applyPatch(updatedBlock, data.patch);
-                  return updatedBlock;
-                }
-                return block;
-              });
-              return { ...msg, responseBlocks: updatedBlocks };
-            }
-            return msg;
-          }),
-        );
-      }
-
-      if (data.type === 'messageEnd') {
-        if (handledMessageEndRef.current.has(messageId)) {
-          return;
+      switch (chunkType) {
+        // forward:
+        case 'stream-start':
+        case 'text-start':
+        case 'text-delta':
+        case 'text-end':
+        case 'reasoning-start':
+        case 'reasoning-delta':
+        case 'reasoning-end':
+        case 'tool-input-start':
+        case 'tool-input-delta':
+        case 'tool-input-end':
+        case 'source':
+        case 'response-metadata':
+        case 'error':
+        case 'raw': {
+          controller.enqueue(chunk);
+          break;
         }
 
-        handledMessageEndRef.current.add(messageId);
-
-        const currentMsg = messagesRef.current.find(
-          (msg) => msg.messageId === messageId,
-        );
-
-        const newHistory: [string, string][] = [
-          ...chatHistory.current,
-          ['human', message.query],
-          [
-            'assistant',
-            currentMsg?.responseBlocks.find((b) => b.type === 'text')?.data ||
-              '',
-          ],
-        ];
-
-        chatHistory.current = newHistory;
-
-        setMessages((prev) =>
-          prev.map((msg) =>
-            msg.messageId === messageId
-              ? { ...msg, status: 'completed' as const }
-              : msg,
-          ),
-        );
-
-        setLoading(false);
-
-        const lastMsg = messagesRef.current[messagesRef.current.length - 1];
-
-        const autoMediaSearch = getAutoMediaSearch();
-
-        if (autoMediaSearch) {
-          setTimeout(() => {
-            document
-              .getElementById(`search-images-${lastMsg.messageId}`)
-              ?.click();
-
-            document
-              .getElementById(`search-videos-${lastMsg.messageId}`)
-              ?.click();
-          }, 200);
-        }
-
-        // Check if there are sources and no suggestions
-
-        const hasSourceBlocks = currentMsg?.responseBlocks.some(
-          (block) => block.type === 'source' && block.data.length > 0,
-        );
-        const hasSuggestions = currentMsg?.responseBlocks.some(
-          (block) => block.type === 'suggestion',
-        );
-
-        if (hasSourceBlocks && !hasSuggestions) {
-          const suggestions = await getSuggestions(newHistory);
-          const suggestionBlock: Block = {
-            id: crypto.randomBytes(7).toString('hex'),
-            type: 'suggestion',
-            data: suggestions,
-          };
-
-          setMessages((prev) =>
-            prev.map((msg) => {
-              if (msg.messageId === messageId) {
-                return {
-                  ...msg,
-                  responseBlocks: [...msg.responseBlocks, suggestionBlock],
-                };
-              }
-              return msg;
+        case 'file': {
+          controller.enqueue({
+            type: 'file',
+            file: new DefaultGeneratedFileWithType({
+              data: chunk.data,
+              mediaType: chunk.mediaType,
             }),
-          );
+            ...(chunk.providerMetadata != null
+              ? { providerMetadata: chunk.providerMetadata }
+              : {}),
+          });
+          break;
+        }
+
+        case 'finish': {
+          finishChunk = {
+            type: 'finish',
+            finishReason: chunk.finishReason.unified,
+            rawFinishReason: chunk.finishReason.raw,
+            usage: asLanguageModelUsage(chunk.usage),
+            providerMetadata: chunk.providerMetadata,
+          };
+          break;
+        }
+
+        case 'tool-approval-request': {
+          const toolCall = toolCallsByToolCallId.get(chunk.toolCallId);
+          if (toolCall == null) {
+            safeEnqueue({
+              type: 'error',
+              error: new ToolCallNotFoundForApprovalError({
+                toolCallId: chunk.toolCallId,
+                approvalId: chunk.approvalId,
+              }),
+            });
+            break;
+          }
+
+          controller.enqueue({
+            type: 'tool-approval-request',
+            approvalId: chunk.approvalId,
+            toolCall,
+          });
+          break;
+        }
+
+        // process tool call:
+        case 'tool-call': {
+          try {
+            const toolCall = await parseToolCall({
+              toolCall: chunk,
+              tools,
+              repairToolCall,
+              system,
+              messages,
+            });
+
+            toolCallsByToolCallId.set(toolCall.toolCallId, toolCall);
+            controller.enqueue(toolCall);
+
+            if (toolCall.invalid) {
+              safeEnqueue({
+                type: 'tool-error',
+                toolCallId: toolCall.toolCallId,
+                toolName: toolCall.toolName,
+                input: toolCall.input,
+                error: getErrorMessage(toolCall.error!),
+                dynamic: true,
+                title: toolCall.title,
+              });
+              break;
+            }
+
+            const tool = tools?.[toolCall.toolName];
+
+            if (tool == null) {
+              // ignore tool calls for tools that are not available,
+              // e.g. provider-executed dynamic tools
+              break;
+            }
+
+            if (tool.onInputAvailable != null) {
+              await tool.onInputAvailable({
+                input: toolCall.input,
+                toolCallId: toolCall.toolCallId,
+                messages,
+                abortSignal,
+                experimental_context,
+              });
+            }
+
+            if (
+              await isApprovalNeeded({
+                tool,
+                toolCall,
+                messages,
+                experimental_context,
+              })
+            ) {
+              safeEnqueue({
+                type: 'tool-approval-request',
+                approvalId: generateId(),
+                toolCall,
+              });
+              break;
+            }
+
+            toolInputs.set(toolCall.toolCallId, toolCall.input);
+
+            // Only execute tools that are not provider-executed:
+            if (tool.execute != null && toolCall.providerExecuted !== true) {
+              const toolExecutionId = generateId(); // use our own id to guarantee uniqueness
+              outstandingToolResults.add(toolExecutionId);
+
+              // Note: we don't await the tool execution here (by leaving out 'await' on recordSpan),
+              // because we want to process the next chunk as soon as possible.
+              // This is important for the case where the tool execution takes a long time.
+              executeToolCall({
+                toolCall,
+                tools,
+                tracer,
+                telemetry,
+                messages,
+                abortSignal,
+                experimental_context,
+                stepNumber,
+                model,
+                onToolCallStart,
+                onToolCallFinish,
+                onPreliminaryToolResult: result => {
+                  safeEnqueue(result);
+                },
+              })
+                .then(result => {
+                  safeEnqueue(result);
+                })
+                .catch(error => {
+                  safeEnqueue({
+                    type: 'error',
+                    error,
+                  });
+                })
+                .finally(() => {
+                  outstandingToolResults.delete(toolExecutionId);
+                  attemptClose();
+                });
+            }
+          } catch (error) {
+            safeEnqueue({ type: 'error', error });
+          }
+
+          break;
+        }
+
+        case 'tool-result': {
+          const toolName = chunk.toolName as keyof TOOLS & string;
+
+          if (chunk.isError) {
+            safeEnqueue({
+              type: 'tool-error',
+              toolCallId: chunk.toolCallId,
+              toolName,
+              input: toolInputs.get(chunk.toolCallId),
+              providerExecuted: true,
+              error: chunk.result,
+              dynamic: chunk.dynamic,
+              ...(chunk.providerMetadata != null
+                ? { providerMetadata: chunk.providerMetadata }
+                : {}),
+            } as TypedToolError<TOOLS>);
+          } else {
+            controller.enqueue({
+              type: 'tool-result',
+              toolCallId: chunk.toolCallId,
+              toolName,
+              input: toolInputs.get(chunk.toolCallId),
+              output: chunk.result,
+              providerExecuted: true,
+              dynamic: chunk.dynamic,
+              ...(chunk.providerMetadata != null
+                ? { providerMetadata: chunk.providerMetadata }
+                : {}),
+            } as TypedToolResult<TOOLS>);
+          }
+          break;
+        }
+
+        default: {
+          const _exhaustiveCheck: never = chunkType;
+          throw new Error(`Unhandled chunk type: ${_exhaustiveCheck}`);
         }
       }
-    };
-  };
+    },
 
-  const sendMessage: ChatContext['sendMessage'] = async (
-    message,
-    messageId,
-    rewrite = false,
-  ) => {
-    if (loading || !message) return;
-    setLoading(true);
-    setResearchEnded(false);
-    setMessageAppeared(false);
+    flush() {
+      canClose = true;
+      attemptClose();
+    },
+  });
 
-    if (messages.length <= 1) {
-      window.history.replaceState(null, '', `/c/${chatId}`);
-    }
-
-    messageId = messageId ?? crypto.randomBytes(7).toString('hex');
-    const backendId = crypto.randomBytes(20).toString('hex');
-
-    const newMessage: Message = {
-      messageId,
-      chatId: chatId!,
-      backendId,
-      query: message,
-      responseBlocks: [],
-      status: 'answering',
-      createdAt: new Date(),
-    };
-
-    setMessages((prevMessages) => [...prevMessages, newMessage]);
-
-    const messageIndex = messages.findIndex((m) => m.messageId === messageId);
-
-    const res = await fetch('/api/chat', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        content: message,
-        message: {
-          messageId: messageId,
-          chatId: chatId!,
-          content: message,
-        },
-        chatId: chatId!,
-        files: fileIds,
-        sources: sources,
-        optimizationMode: optimizationMode,
-        history: rewrite
-          ? chatHistory.current.slice(
-              0,
-              messageIndex === -1 ? undefined : messageIndex,
-            )
-          : chatHistory.current,
-        chatModel: {
-          key: chatModelProvider.key,
-          providerId: chatModelProvider.providerId,
-        },
-        embeddingModel: {
-          key: embeddingModelProvider.key,
-          providerId: embeddingModelProvider.providerId,
-        },
-        systemInstructions: localStorage.getItem('systemInstructions'),
-      }),
-    });
-
-    if (!res.body) throw new Error('No response body');
-
-    const reader = res.body?.getReader();
-    const decoder = new TextDecoder('utf-8');
-
-    let partialChunk = '';
-
-    const messageHandler = getMessageHandler(newMessage);
-
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-
-      partialChunk += decoder.decode(value, { stream: true });
-
-      try {
-        const messages = partialChunk.split('\n');
-        for (const msg of messages) {
-          if (!msg.trim()) continue;
-          const json = JSON.parse(msg);
-          messageHandler(json);
-        }
-        partialChunk = '';
-      } catch (error) {
-        console.warn('Incomplete JSON, waiting for next chunk...');
-      }
-    }
-  };
-
-  return (
-    <chatContext.Provider
-      value={{
-        messages,
-        sections,
-        chatHistory: chatHistory.current,
-        files,
-        fileIds,
-        sources,
-        chatId,
-        hasError,
-        isMessagesLoaded,
-        isReady,
-        loading,
-        messageAppeared,
-        notFound,
-        optimizationMode,
-        setFileIds,
-        setFiles,
-        setSources,
-        setOptimizationMode,
-        rewrite,
-        sendMessage,
-        setChatModelProvider,
-        chatModelProvider,
-        embeddingModelProvider,
-        setEmbeddingModelProvider,
-        researchEnded,
-        setResearchEnded,
-      }}
-    >
-      {children}
-    </chatContext.Provider>
-  );
-};
-
-export const useChat = () => {
-  const ctx = useContext(chatContext);
-  return ctx;
-};
+  // combine the generator stream and the tool results stream
+  return new ReadableStream<SingleRequestTextStreamPart<TOOLS>>({
+    async start(controller) {
+      // need to wait for both pipes so there are no dangling promises that
+      // can cause uncaught promise rejections when the stream is aborted
+      return Promise.all([
+        generatorStream.pipeThrough(forwardStream).pipeTo(
+          new WritableStream({
+            write(chunk) {
+              controller.enqueue(chunk);
+            },
+            close() {
+              // the generator stream controller is automatically closed when it's consumed
+            },
+          }),
+        ),
+        toolResultsStream.pipeTo(
+          new WritableStream({
+            write(chunk) {
+              controller.enqueue(chunk);
+            },
+            close() {
+              controller.close();
+            },
+          }),
+        ),
+      ]);
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #810.

deepseek-r1-671b updated its chat template and now only emits a closing `</think>` tag at the end of its thinking output, without an opening `<think>` tag. The existing thinking-tag logic in `useChat.tsx` handled the reverse case (opening `<think>` without closing `</think>`, which occurs during streaming) but did not handle this case. As a result, the model's thinking content leaked into the main answer instead of being rendered in the ThinkBox component.

## Changes

In `src/lib/hooks/useChat.tsx`, the thinking tag detection in the `sections` useMemo now:

1. Always counts both opening and closing think tags (previously only counted them inside an `if (processedText.includes('<think>'))` guard)
2. Prepends `<think>` when `</think>` is found without a matching opening tag, so the markdown-to-jsx parser can route the content to the ThinkBox component

This ensures models that omit the opening `<think>` tag (like deepseek-r1-671b) still have their thinking content rendered correctly in the collapsible ThinkBox, while the existing streaming behavior (closing tag added when opening tag is present but closing is missing) is preserved.

## Test plan

- [ ] Test with deepseek-r1-671b via custom OpenAI — thinking content should appear in the ThinkBox, not in the main answer
- [ ] Test with deepseek-r1-0528 (which uses both `<think>` and `</think>`) — should continue working as before
- [ ] Test with non-thinking models — no change in behavior (no think tags present)
- [ ] Test streaming behavior — incomplete `<think>` without `</think>` should still get auto-closed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #810. Ensures models that only emit a closing </think> (like `deepseek-r1-671b`) render their thinking in the ThinkBox instead of the main answer.

- **Bug Fixes**
  - In `src/lib/hooks/useChat.tsx`, always count both `<think>` and `</think>` tags during parsing.
  - When `</think>` appears without a matching `<think>`, prepend `<think>` so the markdown parser routes content to the ThinkBox.
  - Preserve existing streaming behavior that auto-closes an open `<think>` without a closing tag.

<sup>Written for commit b688355e1551dab7b6898dc900783981d79894a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

