### PR TITLE
fix: guard against undefined queries/urls in research actions

### DIFF
--- a/src/lib/agents/search/researcher/actions/academicSearch.ts
+++ b/src/lib/agents/search/researcher/actions/academicSearch.ts
@@ -30,7 +30,7 @@ const academicSearchAction: ResearchAction<typeof schema> = {
     config.classification.classification.skipSearch === false &&
     config.classification.classification.academicSearch === true,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    input.queries = (input.queries ?? []).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,

--- a/src/lib/agents/search/researcher/actions/scrapeURL.ts
+++ b/src/lib/agents/search/researcher/actions/scrapeURL.ts
@@ -25,7 +25,7 @@ const scrapeURLAction: ResearchAction<typeof schema> = {
   getDescription: () => actionDescription,
   enabled: (_) => true,
   execute: async (params, additionalConfig) => {
-    params.urls = params.urls.slice(0, 3);
+    params.urls = (params.urls ?? []).slice(0, 3);
 
     let readingBlockId = crypto.randomUUID();
     let readingEmitted = false;

--- a/src/lib/agents/search/researcher/actions/socialSearch.ts
+++ b/src/lib/agents/search/researcher/actions/socialSearch.ts
@@ -30,7 +30,7 @@ const socialSearchAction: ResearchAction<typeof schema> = {
     config.classification.classification.skipSearch === false &&
     config.classification.classification.discussionSearch === true,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    input.queries = (input.queries ?? []).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,

--- a/src/lib/agents/search/researcher/actions/uploadsSearch.ts
+++ b/src/lib/agents/search/researcher/actions/uploadsSearch.ts
@@ -27,7 +27,7 @@ const uploadsSearchAction: ResearchAction<typeof schema> = {
   Never use this tool to search the web or for information that is not contained within the user's uploaded files.
   `,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    input.queries = (input.queries ?? []).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,

--- a/src/lib/agents/search/researcher/actions/webSearch.ts
+++ b/src/lib/agents/search/researcher/actions/webSearch.ts
@@ -85,7 +85,7 @@ const webSearchAction: ResearchAction<typeof actionSchema> = {
     config.sources.includes('web') &&
     config.classification.classification.skipSearch === false,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    input.queries = (input.queries ?? []).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,


### PR DESCRIPTION
## Problem

Every search crashes with `TypeError: Cannot read properties of undefined (reading 'slice')` when the LLM returns incomplete or malformed tool arguments. This happens because all five research actions call `.slice()` directly on the `queries` or `urls` field without checking if it exists first.

When the LLM doesn't return structured arguments properly (due to context limits, model quirks, or malformed tool calls), `actionConfig.arguments` is an empty object `{}`, so `input.queries` / `params.urls` is `undefined`.

## Fix

Added nullish coalescing (`?? []`) before `.slice()` in all five action files:

- `webSearch.ts`
- `academicSearch.ts`
- `socialSearch.ts`
- `uploadsSearch.ts`
- `scrapeURL.ts`

If the field is missing, it defaults to an empty array and the action continues without crashing.

Fixes #964

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented search crashes when the LLM returns missing `queries` or `urls` by defaulting to an empty array before slicing. All five research actions now continue safely instead of throwing "Cannot read properties of undefined (reading 'slice')".

<sup>Written for commit efda0a2d15a242d411c5836ac4fbe12f33cf7353. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

