### PR TITLE
fix: strip markdown code fences before JSON parsing in structured output

### DIFF
--- a/src/lib/models/providers/ollama/ollamaLLM.ts
+++ b/src/lib/models/providers/ollama/ollamaLLM.ts
@@ -21,11 +21,11 @@ import { repairJson } from '@toolsycc/json-repair';
  */
 function stripMarkdownFences(text: string): string {
   const trimmed = text.trim();
-  // Full fence pair: ```json\n...\n```
-  const full = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n?\s*```\s*$/);
+  // Full fence pair: ```json\n...\n``` (or same-line ```json{...}```)
+  const full = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```\s*$/);
   if (full) return full[1].trim();
   // Opening fence only (streaming partial): ```json\n{...
-  const leading = trimmed.match(/^```(?:json)?\s*\n([\s\S]*)$/);
+  const leading = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*)$/);
   if (leading) return leading[1];
   return trimmed;
 }

--- a/src/lib/models/providers/openai/openaiLLM.ts
+++ b/src/lib/models/providers/openai/openaiLLM.ts
@@ -28,11 +28,11 @@ import { repairJson } from '@toolsycc/json-repair';
  */
 function stripMarkdownFences(text: string): string {
   const trimmed = text.trim();
-  // Full fence pair: ```json\n...\n```
-  const full = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n?\s*```\s*$/);
+  // Full fence pair: ```json\n...\n``` (or same-line ```json{...}```)
+  const full = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```\s*$/);
   if (full) return full[1].trim();
   // Opening fence only (streaming partial): ```json\n{...
-  const leading = trimmed.match(/^```(?:json)?\s*\n([\s\S]*)$/);
+  const leading = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*)$/);
   if (leading) return leading[1];
   return trimmed;
 }


### PR DESCRIPTION
## Summary

Fixes #959

Some LLM providers (notably Claude via OpenAI-compatible APIs and certain Ollama models) wrap their structured output in markdown code fences:

````
```json
{"key": "value"}
```
````

This causes `JSON.parse` and `partial-json` to throw parse errors, breaking `generateObject()` and `streamObject()` calls with these models.

## Changes

- Added a `stripMarkdownFences()` helper that removes `` ```json ... ``` `` wrappers before the content reaches `repairJson` / `parse`
- Applied to both **OpenAI** and **Ollama** provider implementations
- Covers both `generateObject()` (full response) and `streamObject()` (streaming partial + final)
- Other providers (Groq, Gemini, Anthropic, LMStudio, Lemonade) extend `OpenAILLM` so they inherit the fix automatically

## Why `repairJson({ extractJson: true })` isn't enough

The existing `repairJson` with `extractJson` handles some cases but doesn't reliably strip markdown fences in all edge cases — particularly when the fence includes a language tag (`json`) or has varying whitespace. The explicit strip before repair makes the pipeline more robust.

## How to test

1. `npm install && npm run dev`, open http://localhost:3000
2. In settings, pick a model that's known to wrap structured output in code fences (e.g. Claude via an OpenAI-compatible proxy, or an Ollama model like `deepseek-r1`)
3. Send a query that triggers the search pipeline (e.g. "latest news about TypeScript") — this exercises `generateObject()` in the classifier
4. Confirm the search completes without a JSON parse error in the terminal logs
5. Also test with a standard OpenAI model (e.g. GPT-4o) to make sure the no-fence path still works — `stripMarkdownFences` should be a no-op when there are no fences