### PR TITLE
fix: prevent repeated text on reconnect by using block snapshots

### DIFF
--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -78,8 +78,6 @@ class SessionManager {
   }
 
   subscribe(listener: (event: string, data: any) => void): () => void {
-    const currentEventsLength = this.events.length;
-
     const handler = (event: string) => (data: any) => listener(event, data);
     const dataHandler = handler('data');
     const endHandler = handler('end');
@@ -89,9 +87,23 @@ class SessionManager {
     this.emitter.on('end', endHandler);
     this.emitter.on('error', errorHandler);
 
-    for (let i = 0; i < currentEventsLength; i++) {
-      const { event, data } = this.events[i];
-      listener(event, data);
+    // Send the current state of each block as a snapshot rather than
+    // replaying every historical event. The old approach replayed all
+    // block creation + every incremental updateBlock patch, which caused
+    // reconnecting clients to visually rebuild (and effectively duplicate)
+    // content they had already received before the connection dropped.
+    for (const block of this.blocks.values()) {
+      listener('data', { type: 'block', block: structuredClone(block) });
+    }
+
+    // Replay any non-block milestone events (researchComplete, end, error)
+    // so reconnecting subscribers know if the session already finished.
+    for (const { event, data } of this.events) {
+      if (event === 'end' || event === 'error') {
+        listener(event, data);
+      } else if (event === 'data' && data.type === 'researchComplete') {
+        listener(event, data);
+      }
     }
 
     return () => {


### PR DESCRIPTION
## Summary

Fixes #938

When a client reconnects to an in-progress session (e.g. after a network blip or tab switch), the `subscribe()` method in `SessionManager` replayed every historical event — every block creation and every incremental `updateBlock` patch. This caused the client to visually rebuild content from scratch, producing duplicated text in the response.

## Root cause

`subscribe()` stored all emitted events in an array and replayed the entire array to new subscribers. On initial connection this was harmless (array was empty), but on reconnect the array contained hundreds of events. The client already had the content from before the disconnect, so replaying everything doubled it.

## Fix

Changed `subscribe()` to send **block snapshots** (current state via `structuredClone`) instead of replaying every historical event. Non-block milestone events (`researchComplete`, `end`, `error`) are still replayed so reconnecting clients know if the session already finished.

This means:
- Initial subscribers (new session) get an empty block map — no replay, same as before
- Reconnecting subscribers get the latest state of each block — no duplication
- If the session ended while disconnected, the client still receives the `end` signal

## How to test

1. `npm install && npm run dev`, open http://localhost:3000
2. Send a search query and while the response is still streaming, open browser DevTools → Network tab
3. Find the active SSE/fetch connection to `/api/chat` and block it (or toggle your network off for a second, then back on) to force a reconnect through `/api/reconnect`
4. The response should continue from where it left off without the text appearing twice
5. Also let a response fully complete, then force a reconnect — the full response should show once, not doubled