### PR TITLE
feat: allow custom Anthropic base URLs

### DIFF
--- a/src/lib/models/providers/anthropic/index.ts
+++ b/src/lib/models/providers/anthropic/index.ts
@@ -8,6 +8,7 @@ import AnthropicLLM from './anthropicLLM';
 
 interface AnthropicConfig {
   apiKey: string;
+  baseURL: string;
 }
 
 const providerConfigFields: UIConfigField[] = [
@@ -21,6 +22,17 @@ const providerConfigFields: UIConfigField[] = [
     env: 'ANTHROPIC_API_KEY',
     scope: 'server',
   },
+  {
+    type: 'string',
+    name: 'Base URL',
+    key: 'baseURL',
+    description: 'The base URL for the Anthropic API',
+    required: true,
+    placeholder: 'Anthropic Base URL',
+    default: 'https://api.anthropic.com/v1',
+    env: 'ANTHROPIC_BASE_URL',
+    scope: 'server',
+  },
 ];
 
 class AnthropicProvider extends BaseModelProvider<AnthropicConfig> {
@@ -28,8 +40,15 @@ class AnthropicProvider extends BaseModelProvider<AnthropicConfig> {
     super(id, name, config);
   }
 
+  private normalizeBaseURL(url: string): string {
+    const trimmed = url.trim().replace(/\/+$/, '');
+    return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+  }
+
   async getDefaultModels(): Promise<ModelList> {
-    const res = await fetch('https://api.anthropic.com/v1/models?limit=999', {
+    const baseURL = this.normalizeBaseURL(this.config.baseURL);
+
+    const res = await fetch(`${baseURL}/models?limit=999`, {
       method: 'GET',
       headers: {
         'x-api-key': this.config.apiKey,
@@ -81,7 +100,7 @@ class AnthropicProvider extends BaseModelProvider<AnthropicConfig> {
     return new AnthropicLLM({
       apiKey: this.config.apiKey,
       model: key,
-      baseURL: 'https://api.anthropic.com/v1',
+      baseURL: this.normalizeBaseURL(this.config.baseURL),
     });
   }
 
@@ -97,6 +116,7 @@ class AnthropicProvider extends BaseModelProvider<AnthropicConfig> {
 
     return {
       apiKey: String(raw.apiKey),
+      baseURL: String(raw.baseURL ?? 'https://api.anthropic.com/v1'),
     };
   }
 


### PR DESCRIPTION
## Summary
- add a configurable `baseURL` field to the Anthropic provider UI/server config
- normalize custom Anthropic-compatible endpoints so users can enter either the root URL or `/v1`
- keep the official Anthropic endpoint as the backward-compatible default for existing configs

Fixes #918.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable `baseURL` for the Anthropic provider to support custom Anthropic-compatible endpoints. Normalizes URLs and keeps `https://api.anthropic.com/v1` as the default. Fixes #918.

- **New Features**
  - Adds `baseURL` field in the provider UI/config with default `https://api.anthropic.com/v1` (`ANTHROPIC_BASE_URL`).
  - Normalizes user input: trims trailing slashes and ensures `/v1` is present.
  - All Anthropic requests (model listing and LLM calls) now use the configured `baseURL`.

- **Migration**
  - No action needed for existing setups; default endpoint remains unchanged.
  - To use a custom proxy, set `ANTHROPIC_BASE_URL` or update the provider settings (accepts root URL or `/v1`).

<sup>Written for commit a640335d155eaf8ddfc62fd89cb253d060b140a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

