### PR TITLE
fix: add typing_extensions to Dockerfile to resolve build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN git clone "https://github.com/searxng/searxng" \
                    "/usr/local/searxng/searxng-src"
 
 RUN python3 -m venv "/usr/local/searxng/searx-pyenv"
-RUN "/usr/local/searxng/searx-pyenv/bin/pip" install --upgrade pip setuptools wheel pyyaml msgspec
+RUN "/usr/local/searxng/searx-pyenv/bin/pip" install --upgrade pip setuptools wheel pyyaml msgspec typing_extensions
 RUN cd "/usr/local/searxng/searxng-src" && \
     "/usr/local/searxng/searx-pyenv/bin/pip" install --use-pep517 --no-build-isolation -e .
 


### PR DESCRIPTION
Add typing_extensions to the list of installed packages to prevent build error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker build by installing `typing_extensions` in the venv, ensuring `msgspec` and other deps have required typing backports and the `searxng` install completes without errors.

<sup>Written for commit 80d4f23765e30cb87c31de3002c37581acda6b70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

