### PR TITLE
fix: strip markdown code fences from LLM JSON responses (fixes #959)

### DIFF
--- a/src/lib/models/providers/ollama/ollamaLLM.ts
+++ b/src/lib/models/providers/ollama/ollamaLLM.ts
@@ -12,6 +12,7 @@ import { parse } from 'partial-json';
 import crypto from 'crypto';
 import { Message } from '@/lib/types';
 import { repairJson } from '@toolsycc/json-repair';
+import { stripMarkdownFences } from '@/lib/utils/parseJson';
 
 type OllamaConfig = {
   baseURL: string;
@@ -249,7 +250,7 @@ class OllamaLLM extends BaseLLM<OllamaConfig> {
       recievedObj += chunk.message.content;
 
       try {
-        yield parse(recievedObj) as T;
+        yield parse(stripMarkdownFences(recievedObj)) as T;
       } catch (err) {
         console.log('Error parsing partial object from Ollama:', err);
         yield {} as T;

--- a/src/lib/models/providers/openai/openaiLLM.ts
+++ b/src/lib/models/providers/openai/openaiLLM.ts
@@ -19,6 +19,7 @@ import {
 } from 'openai/resources/index.mjs';
 import { Message } from '@/lib/types';
 import { repairJson } from '@toolsycc/json-repair';
+import { safeParseJson, stripMarkdownFences } from '@/lib/utils/parseJson';
 
 type OpenAIConfig = {
   apiKey: string;
@@ -110,7 +111,7 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
                 return {
                   name: tc.function.name,
                   id: tc.id,
-                  arguments: JSON.parse(tc.function.arguments),
+                  arguments: safeParseJson(tc.function.arguments),
                 };
               }
             })
@@ -256,14 +257,14 @@ class OpenAILLM extends BaseLLM<OpenAIConfig> {
         recievedObj += chunk.delta;
 
         try {
-          yield parse(recievedObj) as T;
+          yield parse(stripMarkdownFences(recievedObj)) as T;
         } catch (err) {
           console.log('Error parsing partial object from OpenAI:', err);
           yield {} as T;
         }
       } else if (chunk.type === 'response.output_text.done' && chunk.text) {
         try {
-          yield parse(chunk.text) as T;
+          yield parse(stripMarkdownFences(chunk.text)) as T;
         } catch (err) {
           throw new Error(`Error parsing response from OpenAI: ${err}`);
         }

--- a/src/lib/utils/parseJson.ts
+++ b/src/lib/utils/parseJson.ts
@@ -1,0 +1,21 @@
+/**
+ * Strips markdown code fences that some LLM providers (Claude, models via
+ * LiteLLM/OpenRouter) wrap around JSON output.
+ *
+ * Handles ```json ... ```, ``` ... ```, and raw JSON (no-op).
+ */
+export function stripMarkdownFences(text: string): string {
+  return text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim();
+}
+
+/**
+ * Strips markdown code fences from LLM output before JSON.parse.
+ * Fixes issue #959: Claude/LiteLLM models wrap JSON in markdown blocks.
+ */
+export function safeParseJson<T>(text: string): T {
+  return JSON.parse(stripMarkdownFences(text)) as T;
+}


### PR DESCRIPTION
## Problem

Some LLM providers (Claude, models via LiteLLM/OpenRouter) wrap JSON output in markdown code fences:

\\\
\\\json
{ "query": "...", "sources": [...] }
\\\
\\\

The \streamObject()\ paths in both OpenAI and Ollama providers pass accumulated text directly to \partial-json\'s \parse()\, which fails on the fence characters. This affects all users running Claude or any model behind LiteLLM/OpenRouter that wraps JSON in markdown.

## Solution

Added \stripMarkdownFences()\ and \safeParseJson()\ utilities in \src/lib/utils/parseJson.ts\ that strip markdown code fences (\\\json ... \\\ and \\\ ... \\\) before parsing. Applied to:

- **\streamObject()\** in both OpenAI and Ollama providers — strips fences from accumulated partial JSON text before passing to \parse()\
- **\generateText()\** tool call argument parsing in the OpenAI provider

The existing \generateObject()\ paths already use \epairJson()\ with \xtractJson: true\, which handles this case, so those are left unchanged.

## Testing

Tested with Claude 3.5 Sonnet via LiteLLM and OpenRouter — JSON responses with and without fences are now parsed correctly. The fix is a no-op for models that already return clean JSON.

Fixes #959

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip markdown code fences from LLM JSON responses to prevent parse errors in OpenAI and Ollama streaming and OpenAI tool-call paths. Fixes #959.

- **Bug Fixes**
  - Added `stripMarkdownFences()` and `safeParseJson()` in `src/lib/utils/parseJson.ts`.
  - Applied to `streamObject()` for OpenAI and Ollama before calling `parse` from `partial-json`.
  - Used for OpenAI `generateText()` tool-call arguments; `generateObject()` unchanged (already handled by `@toolsycc/json-repair` with `extractJson: true`).

<sup>Written for commit 19f4057384d849aa4c4cf064af262986571d15ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

