### PR TITLE
docs: document sources API parameter and focusMode deprecation (v1.12.1)

### DIFF
--- a/docs/API/SEARCH.md
+++ b/docs/API/SEARCH.md
@@ -15,7 +15,15 @@ The `focusMode` parameter has been removed from all API endpoints and replaced w
 | `"focusMode": "webSearch"` | `"sources": ["web"]` |
 | `"focusMode": "academicSearch"` | `"sources": ["academic"]` |
 
-If you pass `focusMode` to v1.12.1+, it is silently ignored and no sources will be searched. Update your API calls to use `sources` instead.
+> **⚠️ Breaking change in v1.12.1:** The `focusMode` parameter has been removed.
+> Replace `focusMode: "webSearch"` with `sources: ["web"]` in all integrations.
+>
+> **Behaviour by endpoint:**
+> - `/api/chat` — `focusMode` is stripped by Zod schema validation and `sources`
+>   defaults to `[]`. No error is returned, but no sources are searched. Queries
+>   appear to work but return LLM-only answers with no web data.
+> - `/api/search` — `focusMode` is not accepted. Sending `focusMode` without `sources`
+>   returns **HTTP 400** `Missing sources or query`.
 
 ## Endpoints
 
@@ -253,7 +261,7 @@ The `/api/chat` endpoint is the internal streaming API used by Perplexica's fron
 | `optimizationMode` | string | ✅ | `"speed"`, `"balanced"`, or `"quality"` |
 | `history` | array | No | Previous conversation as `["human"/"assistant", "text"]` tuples |
 | `files` | string[] | No | Uploaded file IDs to include in search context |
-| `systemInstructions` | string | No | Custom instructions for the AI |
+| `systemInstructions` | string \| null | No | Custom instructions for the AI (may be null or omitted) |
 
 #### Response Format
 
@@ -263,7 +271,7 @@ Event types:
 
 | Type | Description | Fields |
 |------|-------------|--------|
-| `block` | New content block created | `block: { id, type }` |
+| `block` | New content block created | `block` (full block object, e.g. `{ id, type, data, ... }`) |
 | `updateBlock` | Incremental update to a block | `blockId, patch` (JSON Patch array) |
 | `researchComplete` | Search/research phase finished | — |
 | `messageEnd` | Stream complete | — |


### PR DESCRIPTION
## Context

The v1.12.1 release replaced the \ocusMode\ parameter with \sources\ in the API endpoints. This is a breaking change with no migration documentation — existing integrations that pass \ocusMode\ get no error, but search does not work as expected because no sources are activated.

I discovered this while building an integration and had to read the source code to understand why web search had stopped working after upgrading.

## Changes

Added to \docs/API/SEARCH.md\:

- **Migration guide** with \ocusMode\ → \sources\ mapping table (e.g., \ocusMode: 'webSearch'\ → \sources: ['web']\)
- **Internal \/api/chat\ endpoint documentation** — request body parameters, NDJSON response event types, and JSON Patch accumulation pattern. This is documented as an internal API with a note to prefer \/api/search\ for integrations.

## Impact

This helps:
- Developers upgrading from pre-v1.12.1 who are wondering why search stopped working
- Integration authors who need to understand the \/api/chat\ streaming format
- Anyone building MCP servers, browser extensions, or other tools on top of Perplexica

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the v1.12.1 change replacing `focusMode` with `sources`, adds a migration guide, and updates internal `/api/chat` streaming docs (NDJSON events, JSON Patch, `block.data`). Clarifies endpoint behavior: `/api/chat` returns 200 with LLM-only output when `sources` is omitted, while `/api/search` returns 400; prefer `/api/search`.

- **Migration**
  - Replace `"focusMode": "webSearch"` with `"sources": ["web"]`, and `"academicSearch"` with `["academic"]`.
  - `/api/chat` strips `focusMode` (defaults `sources` to `[]`); `/api/search` rejects it. Update to `sources` and set `systemInstructions` as `string | null`.

<sup>Written for commit 77f0099c0489a2ac6c6393a1dc1ef0ccd99a1d44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

