### PR TITLE
fix(ci): read release tag from event payload

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Extract version from release tag
         if: github.event_name == 'release'
         id: version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Build and push AMD64 Docker image (master)
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
@@ -104,7 +104,7 @@ jobs:
       - name: Extract version from release tag
         if: github.event_name == 'release'
         id: version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Build and push ARM64 Docker image (master)
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
@@ -161,7 +161,7 @@ jobs:
       - name: Extract version from release tag
         if: github.event_name == 'release'
         id: version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Create and push manifest for main
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'


### PR DESCRIPTION
## What
- read the release tag from `github.event.release.tag_name` instead of shell-expanding `GITHUB_REF`
- update all three release-only extraction steps in the Docker workflow so release image tags are populated consistently

## Why
The `v1.12.1` release Docker workflow failed with an empty `RELEASE_VERSION`, which produced invalid manifest/image tags and left the versioned Docker image unpublished. The failed run was `docker-build.yaml` run `20614523992`.

## Testing
- inspected the failed `v1.12.1` release logs (`gh run view 20614523992 --log-failed`) to confirm `RELEASE_VERSION` was empty on the release path
- `git diff --check`
- verified the workflow now uses `github.event.release.tag_name` in all three release extraction steps and no longer references `${GITHUB_REF#refs/tags/}`

Closes #1007

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker release workflow to read the tag from `github.event.release.tag_name`, so `RELEASE_VERSION` is set and images publish correctly. Addresses Linear #1007 where `v1.12.1` produced empty tags.

- **Bug Fixes**
  - Replace `${GITHUB_REF#refs/tags/}` with `github.event.release.tag_name` in all three release-only extraction steps to keep image tags consistent.

<sup>Written for commit 8b79806057a474e4c31f7e96b0b7d46184bac1fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

