### PR TITLE
fix: use playable YouTube embeds in video lightbox

### DIFF
--- a/src/components/SearchVideos.tsx
+++ b/src/components/SearchVideos.tsx
@@ -12,6 +12,22 @@ type Video = {
   iframe_src: string;
 };
 
+const getPlayableIframeSrc = (iframeSrc: string) => {
+  try {
+    const url = new URL(iframeSrc);
+
+    if (url.hostname.endsWith('youtube-nocookie.com')) {
+      url.hostname = 'www.youtube.com';
+    }
+
+    url.searchParams.set('enablejsapi', '1');
+
+    return url.toString();
+  } catch {
+    return `${iframeSrc}${iframeSrc.includes('?') ? '&' : '?'}enablejsapi=1`;
+  }
+};
+
 declare module 'yet-another-react-lightbox' {
   export interface VideoSlide extends GenericSlide {
     type: 'video-slide';
@@ -199,7 +215,7 @@ const Searchvideos = ({
                 return slide.type === 'video-slide' ? (
                   <div className="h-full w-full flex flex-row items-center justify-center">
                     <iframe
-                      src={`${slide.iframe_src}${slide.iframe_src.includes('?') ? '&' : '?'}enablejsapi=1`}
+                      src={getPlayableIframeSrc(slide.iframe_src)}
                       ref={(el) => {
                         if (el) {
                           videoRefs.current[index] = el;


### PR DESCRIPTION
## Summary
- normalize `youtube-nocookie.com` video embeds to `www.youtube.com` before rendering the lightbox iframe
- keep `enablejsapi=1` attached via `URLSearchParams`, with a fallback for malformed URLs

## Testing
- `./node_modules/.bin/eslint src/components/SearchVideos.tsx`
- `./node_modules/.bin/tsc --noEmit`

Closes #799.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure lightbox YouTube embeds are playable by normalizing `youtube-nocookie.com` URLs to `www.youtube.com` and always adding `enablejsapi=1`. Fixes #799 where some videos failed to load in the lightbox.

- **Bug Fixes**
  - Normalize `youtube-nocookie.com` to `www.youtube.com` before rendering the iframe.
  - Always set `enablejsapi=1` via `URLSearchParams`, with a fallback for malformed URLs.

<sup>Written for commit 8e19f2fa0239ce09633db3af790c10279c50bde4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

