### PR TITLE
fix: restore Groq search compatibility

### DIFF
--- a/src/lib/agents/search/researcher/actions/webSearch.ts
+++ b/src/lib/agents/search/researcher/actions/webSearch.ts
@@ -4,7 +4,6 @@ import { searchSearxng } from '@/lib/searxng';
 import { Chunk, SearchResultsResearchBlock } from '@/lib/types';
 
 const actionSchema = z.object({
-  type: z.literal('web_search'),
   queries: z
     .array(z.string())
     .describe('An array of search queries to perform web searches for.'),

--- a/src/lib/models/providers/groq/groqLLM.ts
+++ b/src/lib/models/providers/groq/groqLLM.ts
@@ -1,5 +1,42 @@
+import { repairJson } from '@toolsycc/json-repair';
+import { GenerateObjectInput } from '../../types';
 import OpenAILLM from '../openai/openaiLLM';
 
-class GroqLLM extends OpenAILLM {}
+class GroqLLM extends OpenAILLM {
+  async generateObject<T>(input: GenerateObjectInput): Promise<T> {
+    const response = await this.openAIClient.chat.completions.create({
+      messages: this.convertToOpenAIMessages(input.messages),
+      model: this.config.model,
+      temperature:
+        input.options?.temperature ?? this.config.options?.temperature ?? 1.0,
+      top_p: input.options?.topP ?? this.config.options?.topP,
+      max_completion_tokens:
+        input.options?.maxTokens ?? this.config.options?.maxTokens,
+      stop: input.options?.stopSequences ?? this.config.options?.stopSequences,
+      frequency_penalty:
+        input.options?.frequencyPenalty ??
+        this.config.options?.frequencyPenalty,
+      presence_penalty:
+        input.options?.presencePenalty ?? this.config.options?.presencePenalty,
+      response_format: { type: 'json_object' },
+    });
+
+    if (response.choices && response.choices.length > 0) {
+      try {
+        return input.schema.parse(
+          JSON.parse(
+            repairJson(response.choices[0].message.content || '', {
+              extractJson: true,
+            }) as string,
+          ),
+        ) as T;
+      } catch (err) {
+        throw new Error(`Error parsing response from Groq: ${err}`);
+      }
+    }
+
+    throw new Error('No response from Groq');
+  }
+}
 
 export default GroqLLM;


### PR DESCRIPTION
## Summary
- switch Groq structured-output calls to `json_object` instead of the stricter `json_schema` helper path
- keep Groq JSON parsing resilient by reusing the existing JSON repair/extraction step
- remove the redundant `type` argument requirement from the `web_search` tool schema so Groq/OpenAI-compatible tool calls validate cleanly

## Verification
- `npx tsc --noEmit`
- `npx eslint src/lib/models/providers/groq/groqLLM.ts src/lib/agents/search/researcher/actions/webSearch.ts`
- `npm run build`

Closes #980


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Groq structured-output and search tool compatibility by switching to resilient JSON parsing and aligning the web search action schema. Closes #980.

- **Bug Fixes**
  - In `GroqLLM.generateObject`, request `json_object` and parse with `@toolsycc/json-repair` before schema validation.
  - Remove the redundant `type` field from the `web_search` action schema to validate with Groq/OpenAI tool calls.

<sup>Written for commit bf53e59090046bd538265410dd3d7600ede7bd4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

