### PR TITLE
fix(stream): keep chat SSE alive during long LM Studio generations

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -155,57 +155,72 @@ export const POST = async (req: Request) => {
     const responseStream = new TransformStream();
     const writer = responseStream.writable.getWriter();
     const encoder = new TextEncoder();
+    const keepAliveMs = 15_000;
+    let streamClosed = false;
+    let keepAliveInterval: ReturnType<typeof setInterval> | undefined;
+
+    const safeWrite = (payload: Record<string, unknown>) => {
+      if (streamClosed) return;
+
+      try {
+        writer.write(encoder.encode(JSON.stringify(payload) + '\n'));
+      } catch (error) {
+        console.warn('Failed to write chat stream payload:', error);
+      }
+    };
+
+    const safeClose = () => {
+      if (streamClosed) return;
+
+      streamClosed = true;
+
+      if (keepAliveInterval) {
+        clearInterval(keepAliveInterval);
+      }
+
+      try {
+        writer.close();
+      } catch (error) {
+        console.warn('Failed to close chat stream:', error);
+      }
+    };
+
+    keepAliveInterval = setInterval(() => {
+      safeWrite({ type: 'keepAlive' });
+    }, keepAliveMs);
+
+    safeWrite({ type: 'keepAlive' });
 
     const disconnect = session.subscribe((event: string, data: any) => {
       if (event === 'data') {
         if (data.type === 'block') {
-          writer.write(
-            encoder.encode(
-              JSON.stringify({
-                type: 'block',
-                block: data.block,
-              }) + '\n',
-            ),
-          );
+          safeWrite({
+            type: 'block',
+            block: data.block,
+          });
         } else if (data.type === 'updateBlock') {
-          writer.write(
-            encoder.encode(
-              JSON.stringify({
-                type: 'updateBlock',
-                blockId: data.blockId,
-                patch: data.patch,
-              }) + '\n',
-            ),
-          );
+          safeWrite({
+            type: 'updateBlock',
+            blockId: data.blockId,
+            patch: data.patch,
+          });
         } else if (data.type === 'researchComplete') {
-          writer.write(
-            encoder.encode(
-              JSON.stringify({
-                type: 'researchComplete',
-              }) + '\n',
-            ),
-          );
+          safeWrite({
+            type: 'researchComplete',
+          });
         }
       } else if (event === 'end') {
-        writer.write(
-          encoder.encode(
-            JSON.stringify({
-              type: 'messageEnd',
-            }) + '\n',
-          ),
-        );
-        writer.close();
+        safeWrite({
+          type: 'messageEnd',
+        });
+        safeClose();
         session.removeAllListeners();
       } else if (event === 'error') {
-        writer.write(
-          encoder.encode(
-            JSON.stringify({
-              type: 'error',
-              data: data.data,
-            }) + '\n',
-          ),
-        );
-        writer.close();
+        safeWrite({
+          type: 'error',
+          data: data.data,
+        });
+        safeClose();
         session.removeAllListeners();
       }
     });
@@ -234,7 +249,7 @@ export const POST = async (req: Request) => {
 
     req.signal.addEventListener('abort', () => {
       disconnect();
-      writer.close();
+      safeClose();
     });
 
     return new Response(responseStream.readable, {

--- a/src/app/api/reconnect/[id]/route.ts
+++ b/src/app/api/reconnect/[id]/route.ts
@@ -16,64 +16,79 @@ export const POST = async (
     const responseStream = new TransformStream();
     const writer = responseStream.writable.getWriter();
     const encoder = new TextEncoder();
+    const keepAliveMs = 15_000;
+    let streamClosed = false;
+    let keepAliveInterval: ReturnType<typeof setInterval> | undefined;
+
+    const safeWrite = (payload: Record<string, unknown>) => {
+      if (streamClosed) return;
+
+      try {
+        writer.write(encoder.encode(JSON.stringify(payload) + '\n'));
+      } catch (error) {
+        console.warn('Failed to write reconnect stream payload:', error);
+      }
+    };
+
+    const safeClose = () => {
+      if (streamClosed) return;
+
+      streamClosed = true;
+
+      if (keepAliveInterval) {
+        clearInterval(keepAliveInterval);
+      }
+
+      try {
+        writer.close();
+      } catch (error) {
+        console.warn('Failed to close reconnect stream:', error);
+      }
+    };
+
+    keepAliveInterval = setInterval(() => {
+      safeWrite({ type: 'keepAlive' });
+    }, keepAliveMs);
+
+    safeWrite({ type: 'keepAlive' });
 
     const disconnect = session.subscribe((event, data) => {
       if (event === 'data') {
         if (data.type === 'block') {
-          writer.write(
-            encoder.encode(
-              JSON.stringify({
-                type: 'block',
-                block: data.block,
-              }) + '\n',
-            ),
-          );
+          safeWrite({
+            type: 'block',
+            block: data.block,
+          });
         } else if (data.type === 'updateBlock') {
-          writer.write(
-            encoder.encode(
-              JSON.stringify({
-                type: 'updateBlock',
-                blockId: data.blockId,
-                patch: data.patch,
-              }) + '\n',
-            ),
-          );
+          safeWrite({
+            type: 'updateBlock',
+            blockId: data.blockId,
+            patch: data.patch,
+          });
         } else if (data.type === 'researchComplete') {
-          writer.write(
-            encoder.encode(
-              JSON.stringify({
-                type: 'researchComplete',
-              }) + '\n',
-            ),
-          );
+          safeWrite({
+            type: 'researchComplete',
+          });
         }
       } else if (event === 'end') {
-        writer.write(
-          encoder.encode(
-            JSON.stringify({
-              type: 'messageEnd',
-            }) + '\n',
-          ),
-        );
-        writer.close();
+        safeWrite({
+          type: 'messageEnd',
+        });
+        safeClose();
         disconnect();
       } else if (event === 'error') {
-        writer.write(
-          encoder.encode(
-            JSON.stringify({
-              type: 'error',
-              data: data.data,
-            }) + '\n',
-          ),
-        );
-        writer.close();
+        safeWrite({
+          type: 'error',
+          data: data.data,
+        });
+        safeClose();
         disconnect();
       }
     });
 
     req.signal.addEventListener('abort', () => {
       disconnect();
-      writer.close();
+      safeClose();
     });
 
     return new Response(responseStream.readable, {

--- a/src/lib/hooks/useChat.tsx
+++ b/src/lib/hooks/useChat.tsx
@@ -551,6 +551,10 @@ export const ChatProvider = ({ children }: { children: React.ReactNode }) => {
     const messageId = message.messageId;
 
     return async (data: any) => {
+      if (data.type === 'keepAlive') {
+        return;
+      }
+
       if (data.type === 'error') {
         toast.error(data.data);
         setLoading(false);


### PR DESCRIPTION
## Summary
- send lightweight `keepAlive` frames every 15s on chat and reconnect SSE streams
- emit an immediate keepalive frame so long-running LM Studio requests don't start with a completely idle response
- ignore keepalive frames in the chat client while preserving existing block/update/error handling

## Why
Long-running LM Studio generations can leave the `/api/chat` response completely idle for minutes before the first real block arrives. That makes it easier for the browser/proxy side to tear down the SSE connection, which in turn aborts the upstream model request and shows up in LM Studio as the client disconnecting mid-generation.

Keeping the SSE stream warm avoids that idle gap without changing message semantics.

Closes #1030

## Testing
- `./node_modules/.bin/tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep SSE chat streams alive during long LM Studio generations by sending lightweight `keepAlive` frames and making stream writes/closes safe. Prevents browser/proxy timeouts and upstream model aborts. Addresses #1030.

- **Bug Fixes**
  - Send `keepAlive` every 15s and immediately on start for `/api/chat` and `/api/reconnect/[id]`.
  - Add safe write/close helpers with interval cleanup to avoid stream errors and leaks.
  - Ignore `keepAlive` frames in `useChat` so existing block/update/error handling stays unchanged.

<sup>Written for commit 051ea7768a9c33a815d92438fb9ef6507cf58eb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

