### PR TITLE
fix: block local/private URL scraping in scrape tool

### DIFF
--- a/src/lib/agents/search/researcher/actions/scrapeURL.ts
+++ b/src/lib/agents/search/researcher/actions/scrapeURL.ts
@@ -1,10 +1,21 @@
+import { Chunk, ReadingResearchBlock } from '@/lib/types';
+import dns from 'node:dns/promises';
+import net from 'node:net';
+import TurnDown from 'turndown';
 import z from 'zod';
 import { ResearchAction } from '../../types';
-import { Chunk, ReadingResearchBlock } from '@/lib/types';
-import TurnDown from 'turndown';
-import path from 'path';
 
 const turndownService = new TurnDown();
+const MAX_REDIRECTS = 5;
+const BLOCKED_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1']);
+const BLOCKED_HOST_SUFFIXES = [
+  '.localhost',
+  '.local',
+  '.localdomain',
+  '.internal',
+  '.lan',
+  '.home.arpa',
+];
 
 const schema = z.object({
   urls: z.array(z.string()).describe('A list of URLs to scrape content from.'),
@@ -16,6 +27,147 @@ You should only call this tool when the user has specifically requested informat
 
 For example, if the user says "Please summarize the content of https://example.com/article", you can call this tool with that URL to get the content and then provide the summary or "What does X mean according to https://example.com/page", you can call this tool with that URL to get the content and provide the explanation.
 `;
+
+const normalizeAddress = (address: string) =>
+  address
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '')
+    .split('%')[0];
+
+const isBlockedIPv4 = (address: string): boolean => {
+  const octets = address.split('.').map((part) => Number.parseInt(part, 10));
+
+  if (octets.length !== 4 || octets.some((part) => Number.isNaN(part))) {
+    return false;
+  }
+
+  const [a, b] = octets;
+
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+};
+
+const isBlockedIPv6 = (address: string): boolean => {
+  const normalized = normalizeAddress(address);
+
+  if (normalized === '::1' || normalized === '::') {
+    return true;
+  }
+
+  if (normalized.startsWith('::ffff:')) {
+    return isBlockedIPAddress(normalized.slice('::ffff:'.length));
+  }
+
+  return (
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    normalized.startsWith('fe8') ||
+    normalized.startsWith('fe9') ||
+    normalized.startsWith('fea') ||
+    normalized.startsWith('feb')
+  );
+};
+
+const isBlockedIPAddress = (address: string): boolean => {
+  const normalized = normalizeAddress(address);
+  const version = net.isIP(normalized);
+
+  if (version === 4) {
+    return isBlockedIPv4(normalized);
+  }
+
+  if (version === 6) {
+    return isBlockedIPv6(normalized);
+  }
+
+  return false;
+};
+
+const isBlockedHostname = (hostname: string): boolean => {
+  const normalized = hostname.toLowerCase();
+
+  return (
+    BLOCKED_HOSTNAMES.has(normalized) ||
+    BLOCKED_HOST_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
+  );
+};
+
+const assertSafeScrapeURL = async (rawURL: string): Promise<URL> => {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(rawURL);
+  } catch {
+    throw new Error(`Invalid URL: ${rawURL}`);
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(
+      `Unsupported URL protocol for scraping: ${parsed.protocol}`,
+    );
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (isBlockedHostname(hostname) || isBlockedIPAddress(hostname)) {
+    throw new Error(
+      `Refusing to access local or private network URL: ${rawURL}`,
+    );
+  }
+
+  try {
+    const resolved = await dns.lookup(hostname, { all: true, verbatim: true });
+
+    if (resolved.some((entry) => isBlockedIPAddress(entry.address))) {
+      throw new Error(
+        `Refusing to access local or private network URL: ${rawURL}`,
+      );
+    }
+  } catch (error: any) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith(
+        'Refusing to access local or private network URL:',
+      )
+    ) {
+      throw error;
+    }
+  }
+
+  return parsed;
+};
+
+const fetchScrapeURL = async (
+  rawURL: string,
+  redirectCount = 0,
+): Promise<Response> => {
+  const safeURL = await assertSafeScrapeURL(rawURL);
+  const res = await fetch(safeURL, { redirect: 'manual' });
+
+  if (res.status >= 300 && res.status < 400) {
+    if (redirectCount >= MAX_REDIRECTS) {
+      throw new Error(`Too many redirects while scraping ${rawURL}`);
+    }
+
+    const location = res.headers.get('location');
+
+    if (!location) {
+      throw new Error(`Redirect missing location while scraping ${rawURL}`);
+    }
+
+    const redirectedURL = new URL(location, safeURL).toString();
+    return fetchScrapeURL(redirectedURL, redirectCount + 1);
+  }
+
+  return res;
+};
 
 const scrapeURLAction: ResearchAction<typeof schema> = {
   name: 'scrape_url',
@@ -39,7 +191,7 @@ const scrapeURLAction: ResearchAction<typeof schema> = {
     await Promise.all(
       params.urls.map(async (url) => {
         try {
-          const res = await fetch(url);
+          const res = await fetchScrapeURL(url);
           const text = await res.text();
 
           const title =


### PR DESCRIPTION
## Summary
- block `scrape_url` requests to localhost, private IP ranges, and hostnames that resolve to local/private addresses
- reject non-HTTP(S) scrape targets and validate redirect destinations before following them
- keep the change scoped to the explicit URL-scraping tool used for user-requested page summaries

Fixes #949.

## Testing
- `./node_modules/.bin/eslint src/lib/agents/search/researcher/actions/scrapeURL.ts`
- `./node_modules/.bin/tsc --noEmit`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block scraping of localhost and private network URLs in the `scrape_url` tool to prevent SSRF and unsafe requests. Only HTTP(S) targets are allowed, with validated and limited redirects. Fixes #949.

- **Bug Fixes**
  - Block `localhost`, loopback, and private IP ranges (IPv4/IPv6), plus common local TLDs.
  - Validate DNS results and reject hostnames that resolve to local/private addresses.
  - Allow only HTTP(S); follow redirects manually with validation and a 5-hop limit.
  - Scope change to the `scrape_url` tool used for user-requested page summaries.

<sup>Written for commit b56ac1031359089d680eb5267478fb7266264a0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

