### PR TITLE
fix: cap search writer context before final answer generation

### DIFF
--- a/src/lib/agents/search/api.ts
+++ b/src/lib/agents/search/api.ts
@@ -4,6 +4,7 @@ import { classify } from './classifier';
 import Researcher from './researcher';
 import { getWriterPrompt } from '@/lib/prompts/search/writer';
 import { WidgetExecutor } from './widgets';
+import { buildSearchResultsContext } from './context';
 
 class APISearchAgent {
   async searchAsync(session: SessionManager, input: SearchAgentInput) {
@@ -52,13 +53,9 @@ class APISearchAgent {
       type: 'researchComplete',
     });
 
-    const finalContext =
-      searchResults?.searchFindings
-        .map(
-          (f, index) =>
-            `<result index=${index + 1} title=${f.metadata.title}>${f.content}</result>`,
-        )
-        .join('\n') || '';
+    const finalContext = buildSearchResultsContext(
+      searchResults?.searchFindings || [],
+    );
 
     const widgetContext = widgetOutputs
       .map((o) => {

--- a/src/lib/agents/search/context.ts
+++ b/src/lib/agents/search/context.ts
@@ -1,0 +1,60 @@
+import { Chunk } from '@/lib/types';
+import { getTokenCount, truncateTextByTokens } from '@/lib/utils/splitText';
+
+const MAX_TOTAL_SEARCH_CONTEXT_TOKENS = 20000;
+const MAX_RESULT_CONTEXT_TOKENS = 2500;
+const TRUNCATION_NOTE =
+  '\n[Result content truncated to fit the model context window.]';
+
+const escapeAttribute = (value: string) =>
+  value.replace(/[<>]/g, '').replace(/"/g, '&quot;');
+
+export const buildSearchResultsContext = (searchFindings: Chunk[] = []) => {
+  let remainingTokens = MAX_TOTAL_SEARCH_CONTEXT_TOKENS;
+  const contextParts: string[] = [];
+
+  for (const [index, finding] of searchFindings.entries()) {
+    if (remainingTokens <= 0) {
+      break;
+    }
+
+    const title = escapeAttribute(
+      String(finding.metadata?.title || `Result ${index + 1}`),
+    );
+    const prefix = `<result index=${index + 1} title="${title}">`;
+    const suffix = `</result>`;
+    const wrapperTokens = getTokenCount(prefix) + getTokenCount(suffix);
+    const availableContentTokens = Math.min(
+      MAX_RESULT_CONTEXT_TOKENS,
+      remainingTokens - wrapperTokens,
+    );
+
+    if (availableContentTokens <= 0) {
+      break;
+    }
+
+    const fullContent = String(finding.content || '');
+    const fullContentTokens = getTokenCount(fullContent);
+    let content = truncateTextByTokens(fullContent, availableContentTokens);
+
+    if (fullContentTokens > availableContentTokens) {
+      const noteBudget = Math.max(
+        0,
+        availableContentTokens - getTokenCount(TRUNCATION_NOTE),
+      );
+      content = `${truncateTextByTokens(fullContent, noteBudget)}${TRUNCATION_NOTE}`;
+    }
+
+    const entry = `${prefix}${content}${suffix}`;
+    const entryTokens = getTokenCount(entry);
+
+    if (entryTokens > remainingTokens) {
+      break;
+    }
+
+    contextParts.push(entry);
+    remainingTokens -= entryTokens;
+  }
+
+  return contextParts.join('\n');
+};

--- a/src/lib/agents/search/index.ts
+++ b/src/lib/agents/search/index.ts
@@ -8,6 +8,7 @@ import db from '@/lib/db';
 import { chats, messages } from '@/lib/db/schema';
 import { and, eq, gt } from 'drizzle-orm';
 import { TextBlock } from '@/lib/types';
+import { buildSearchResultsContext } from './context';
 
 class SearchAgent {
   async searchAsync(session: SessionManager, input: SearchAgentInput) {
@@ -98,13 +99,9 @@ class SearchAgent {
       type: 'researchComplete',
     });
 
-    const finalContext =
-      searchResults?.searchFindings
-        .map(
-          (f, index) =>
-            `<result index=${index + 1} title=${f.metadata.title}>${f.content}</result>`,
-        )
-        .join('\n') || '';
+    const finalContext = buildSearchResultsContext(
+      searchResults?.searchFindings || [],
+    );
 
     const widgetContext = widgetOutputs
       .map((o) => {

--- a/src/lib/utils/splitText.ts
+++ b/src/lib/utils/splitText.ts
@@ -4,12 +4,43 @@ const splitRegex = /(?<=\. |\n|! |\? |; |:\s|\d+\.\s|- |\* )/g;
 
 const enc = getEncoding('cl100k_base');
 
-const getTokenCount = (text: string): number => {
+export const getTokenCount = (text: string): number => {
   try {
     return enc.encode(text).length;
   } catch {
     return Math.ceil(text.length / 4);
   }
+};
+
+export const truncateTextByTokens = (
+  text: string,
+  maxTokens: number,
+): string => {
+  if (maxTokens <= 0 || text.length === 0) {
+    return '';
+  }
+
+  if (getTokenCount(text) <= maxTokens) {
+    return text;
+  }
+
+  let low = 0;
+  let high = text.length;
+  let best = '';
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidate = text.slice(0, mid);
+
+    if (getTokenCount(candidate) <= maxTokens) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return best.trimEnd();
 };
 
 export const splitText = (


### PR DESCRIPTION
## Summary
- cap the search-result context passed into the final writer call so large result sets do not overflow model context windows
- truncate individual results with a small note while preserving source ordering and citations
- apply the same capped context builder to both the main chat search flow and the API search flow

## Testing
- npm install
- npx prettier --write src/lib/utils/splitText.ts src/lib/agents/search/context.ts src/lib/agents/search/index.ts src/lib/agents/search/api.ts
- npx tsc --noEmit
- npx eslint src/lib/utils/splitText.ts src/lib/agents/search/context.ts src/lib/agents/search/index.ts src/lib/agents/search/api.ts

Fixes #1011

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps search-result context passed to the final writer to prevent model context window overflow. Truncates long results with a brief note and applies the cap to both chat and API search flows.

- **Bug Fixes**
  - Add `buildSearchResultsContext` with a 20k-token total budget and 2.5k per-result cap.
  - Implement token-based truncation via `truncateTextByTokens`; export `getTokenCount`.
  - Escape result titles in attributes; preserve source order and citations.
  - Use the shared context builder in both `SearchAgent` and `APISearchAgent`.

<sup>Written for commit 0d09a9a29972e356d8fd07905543136dfa5379a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

