### PR TITLE
fix: stop search failures from hanging on Brainstorming

### DIFF
--- a/src/lib/agents/search/api.ts
+++ b/src/lib/agents/search/api.ts
@@ -7,95 +7,102 @@ import { WidgetExecutor } from './widgets';
 
 class APISearchAgent {
   async searchAsync(session: SessionManager, input: SearchAgentInput) {
-    const classification = await classify({
-      chatHistory: input.chatHistory,
-      enabledSources: input.config.sources,
-      query: input.followUp,
-      llm: input.config.llm,
-    });
+    try {
+      const classification = await classify({
+        chatHistory: input.chatHistory,
+        enabledSources: input.config.sources,
+        query: input.followUp,
+        llm: input.config.llm,
+      });
 
-    const widgetPromise = WidgetExecutor.executeAll({
-      classification,
-      chatHistory: input.chatHistory,
-      followUp: input.followUp,
-      llm: input.config.llm,
-    }).catch((err) => {
-      console.error(`Error executing widgets: ${err}`);
-      return [];
-    });
-
-    let searchPromise: Promise<ResearcherOutput> | null = null;
-
-    if (!classification.classification.skipSearch) {
-      const researcher = new Researcher();
-      searchPromise = researcher.research(SessionManager.createSession(), {
+      const widgetPromise = WidgetExecutor.executeAll({
+        classification,
         chatHistory: input.chatHistory,
         followUp: input.followUp,
-        classification: classification,
-        config: input.config,
+        llm: input.config.llm,
+      }).catch((err) => {
+        console.error(`Error executing widgets: ${err}`);
+        return [];
       });
-    }
 
-    const [widgetOutputs, searchResults] = await Promise.all([
-      widgetPromise,
-      searchPromise,
-    ]);
+      let searchPromise: Promise<ResearcherOutput> | null = null;
 
-    if (searchResults) {
+      if (!classification.classification.skipSearch) {
+        const researcher = new Researcher();
+        searchPromise = researcher.research(SessionManager.createSession(), {
+          chatHistory: input.chatHistory,
+          followUp: input.followUp,
+          classification: classification,
+          config: input.config,
+        });
+      }
+
+      const [widgetOutputs, searchResults] = await Promise.all([
+        widgetPromise,
+        searchPromise,
+      ]);
+
+      if (searchResults) {
+        session.emit('data', {
+          type: 'searchResults',
+          data: searchResults.searchFindings,
+        });
+      }
+
       session.emit('data', {
-        type: 'searchResults',
-        data: searchResults.searchFindings,
+        type: 'researchComplete',
+      });
+
+      const finalContext =
+        searchResults?.searchFindings
+          .map(
+            (f, index) =>
+              `<result index=${index + 1} title=${f.metadata.title}>${f.content}</result>`,
+          )
+          .join('\n') || '';
+
+      const widgetContext = widgetOutputs
+        .map((o) => {
+          return `<result>${o.llmContext}</result>`;
+        })
+        .join('\n-------------\n');
+
+      const finalContextWithWidgets = `<search_results note="These are the search results and assistant can cite these">\n${finalContext}\n</search_results>\n<widgets_result noteForAssistant="Its output is already showed to the user, assistant can use this information to answer the query but do not CITE this as a souce">\n${widgetContext}\n</widgets_result>`;
+
+      const writerPrompt = getWriterPrompt(
+        finalContextWithWidgets,
+        input.config.systemInstructions,
+        input.config.mode,
+      );
+
+      const answerStream = input.config.llm.streamText({
+        messages: [
+          {
+            role: 'system',
+            content: writerPrompt,
+          },
+          ...input.chatHistory,
+          {
+            role: 'user',
+            content: input.followUp,
+          },
+        ],
+      });
+
+      for await (const chunk of answerStream) {
+        session.emit('data', {
+          type: 'response',
+          data: chunk.contentChunk,
+        });
+      }
+
+      session.emit('end', {});
+    } catch (error) {
+      console.error('Error while running API search:', error);
+      session.emit('error', {
+        data: error instanceof Error ? error.message : 'Search failed',
       });
     }
-
-    session.emit('data', {
-      type: 'researchComplete',
-    });
-
-    const finalContext =
-      searchResults?.searchFindings
-        .map(
-          (f, index) =>
-            `<result index=${index + 1} title=${f.metadata.title}>${f.content}</result>`,
-        )
-        .join('\n') || '';
-
-    const widgetContext = widgetOutputs
-      .map((o) => {
-        return `<result>${o.llmContext}</result>`;
-      })
-      .join('\n-------------\n');
-
-    const finalContextWithWidgets = `<search_results note="These are the search results and assistant can cite these">\n${finalContext}\n</search_results>\n<widgets_result noteForAssistant="Its output is already showed to the user, assistant can use this information to answer the query but do not CITE this as a souce">\n${widgetContext}\n</widgets_result>`;
-
-    const writerPrompt = getWriterPrompt(
-      finalContextWithWidgets,
-      input.config.systemInstructions,
-      input.config.mode,
-    );
-
-    const answerStream = input.config.llm.streamText({
-      messages: [
-        {
-          role: 'system',
-          content: writerPrompt,
-        },
-        ...input.chatHistory,
-        {
-          role: 'user',
-          content: input.followUp,
-        },
-      ],
-    });
-
-    for await (const chunk of answerStream) {
-      session.emit('data', {
-        type: 'response',
-        data: chunk.contentChunk,
-      });
-    }
-
-    session.emit('end', {});
   }
 }
 

--- a/src/lib/agents/search/index.ts
+++ b/src/lib/agents/search/index.ts
@@ -11,36 +11,168 @@ import { TextBlock } from '@/lib/types';
 
 class SearchAgent {
   async searchAsync(session: SessionManager, input: SearchAgentInput) {
-    const exists = await db.query.messages.findFirst({
-      where: and(
-        eq(messages.chatId, input.chatId),
-        eq(messages.messageId, input.messageId),
-      ),
-    });
-
-    if (!exists) {
-      await db.insert(messages).values({
-        chatId: input.chatId,
-        messageId: input.messageId,
-        backendId: session.id,
-        query: input.followUp,
-        createdAt: new Date().toISOString(),
-        status: 'answering',
-        responseBlocks: [],
+    try {
+      const exists = await db.query.messages.findFirst({
+        where: and(
+          eq(messages.chatId, input.chatId),
+          eq(messages.messageId, input.messageId),
+        ),
       });
-    } else {
-      await db
-        .delete(messages)
-        .where(
-          and(eq(messages.chatId, input.chatId), gt(messages.id, exists.id)),
-        )
-        .execute();
+
+      if (!exists) {
+        await db.insert(messages).values({
+          chatId: input.chatId,
+          messageId: input.messageId,
+          backendId: session.id,
+          query: input.followUp,
+          createdAt: new Date().toISOString(),
+          status: 'answering',
+          responseBlocks: [],
+        });
+      } else {
+        await db
+          .delete(messages)
+          .where(
+            and(eq(messages.chatId, input.chatId), gt(messages.id, exists.id)),
+          )
+          .execute();
+        await db
+          .update(messages)
+          .set({
+            status: 'answering',
+            backendId: session.id,
+            responseBlocks: [],
+          })
+          .where(
+            and(
+              eq(messages.chatId, input.chatId),
+              eq(messages.messageId, input.messageId),
+            ),
+          )
+          .execute();
+      }
+
+      const classification = await classify({
+        chatHistory: input.chatHistory,
+        enabledSources: input.config.sources,
+        query: input.followUp,
+        llm: input.config.llm,
+      });
+
+      const widgetPromise = WidgetExecutor.executeAll({
+        classification,
+        chatHistory: input.chatHistory,
+        followUp: input.followUp,
+        llm: input.config.llm,
+      }).then((widgetOutputs) => {
+        widgetOutputs.forEach((o) => {
+          session.emitBlock({
+            id: crypto.randomUUID(),
+            type: 'widget',
+            data: {
+              widgetType: o.type,
+              params: o.data,
+            },
+          });
+        });
+        return widgetOutputs;
+      });
+
+      let searchPromise: Promise<ResearcherOutput> | null = null;
+
+      if (!classification.classification.skipSearch) {
+        const researcher = new Researcher();
+        searchPromise = researcher.research(session, {
+          chatHistory: input.chatHistory,
+          followUp: input.followUp,
+          classification: classification,
+          config: input.config,
+        });
+      }
+
+      const [widgetOutputs, searchResults] = await Promise.all([
+        widgetPromise,
+        searchPromise,
+      ]);
+
+      session.emit('data', {
+        type: 'researchComplete',
+      });
+
+      const finalContext =
+        searchResults?.searchFindings
+          .map(
+            (f, index) =>
+              `<result index=${index + 1} title=${f.metadata.title}>${f.content}</result>`,
+          )
+          .join('\n') || '';
+
+      const widgetContext = widgetOutputs
+        .map((o) => {
+          return `<result>${o.llmContext}</result>`;
+        })
+        .join('\n-------------\n');
+
+      const finalContextWithWidgets = `<search_results note="These are the search results and assistant can cite these">\n${finalContext}\n</search_results>\n<widgets_result noteForAssistant="Its output is already showed to the user, assistant can use this information to answer the query but do not CITE this as a souce">\n${widgetContext}\n</widgets_result>`;
+
+      const writerPrompt = getWriterPrompt(
+        finalContextWithWidgets,
+        input.config.systemInstructions,
+        input.config.mode,
+      );
+      const answerStream = input.config.llm.streamText({
+        messages: [
+          {
+            role: 'system',
+            content: writerPrompt,
+          },
+          ...input.chatHistory,
+          {
+            role: 'user',
+            content: input.followUp,
+          },
+        ],
+      });
+
+      let responseBlockId = '';
+
+      for await (const chunk of answerStream) {
+        if (!responseBlockId) {
+          const block: TextBlock = {
+            id: crypto.randomUUID(),
+            type: 'text',
+            data: chunk.contentChunk,
+          };
+
+          session.emitBlock(block);
+
+          responseBlockId = block.id;
+        } else {
+          const block = session.getBlock(responseBlockId) as TextBlock | null;
+
+          if (!block) {
+            continue;
+          }
+
+          block.data += chunk.contentChunk;
+
+          session.updateBlock(block.id, [
+            {
+              op: 'replace',
+              path: '/data',
+              value: block.data,
+            },
+          ]);
+        }
+      }
+
+      session.emit('end', {});
+
       await db
         .update(messages)
         .set({
-          status: 'answering',
-          backendId: session.id,
-          responseBlocks: [],
+          status: 'completed',
+          responseBlocks: session.getAllBlocks(),
         })
         .where(
           and(
@@ -49,137 +181,30 @@ class SearchAgent {
           ),
         )
         .execute();
-    }
-
-    const classification = await classify({
-      chatHistory: input.chatHistory,
-      enabledSources: input.config.sources,
-      query: input.followUp,
-      llm: input.config.llm,
-    });
-
-    const widgetPromise = WidgetExecutor.executeAll({
-      classification,
-      chatHistory: input.chatHistory,
-      followUp: input.followUp,
-      llm: input.config.llm,
-    }).then((widgetOutputs) => {
-      widgetOutputs.forEach((o) => {
-        session.emitBlock({
-          id: crypto.randomUUID(),
-          type: 'widget',
-          data: {
-            widgetType: o.type,
-            params: o.data,
-          },
-        });
+    } catch (error) {
+      console.error('Error while running search:', error);
+      session.emit('error', {
+        data: error instanceof Error ? error.message : 'Search failed',
       });
-      return widgetOutputs;
-    });
 
-    let searchPromise: Promise<ResearcherOutput> | null = null;
-
-    if (!classification.classification.skipSearch) {
-      const researcher = new Researcher();
-      searchPromise = researcher.research(session, {
-        chatHistory: input.chatHistory,
-        followUp: input.followUp,
-        classification: classification,
-        config: input.config,
-      });
-    }
-
-    const [widgetOutputs, searchResults] = await Promise.all([
-      widgetPromise,
-      searchPromise,
-    ]);
-
-    session.emit('data', {
-      type: 'researchComplete',
-    });
-
-    const finalContext =
-      searchResults?.searchFindings
-        .map(
-          (f, index) =>
-            `<result index=${index + 1} title=${f.metadata.title}>${f.content}</result>`,
-        )
-        .join('\n') || '';
-
-    const widgetContext = widgetOutputs
-      .map((o) => {
-        return `<result>${o.llmContext}</result>`;
-      })
-      .join('\n-------------\n');
-
-    const finalContextWithWidgets = `<search_results note="These are the search results and assistant can cite these">\n${finalContext}\n</search_results>\n<widgets_result noteForAssistant="Its output is already showed to the user, assistant can use this information to answer the query but do not CITE this as a souce">\n${widgetContext}\n</widgets_result>`;
-
-    const writerPrompt = getWriterPrompt(
-      finalContextWithWidgets,
-      input.config.systemInstructions,
-      input.config.mode,
-    );
-    const answerStream = input.config.llm.streamText({
-      messages: [
-        {
-          role: 'system',
-          content: writerPrompt,
-        },
-        ...input.chatHistory,
-        {
-          role: 'user',
-          content: input.followUp,
-        },
-      ],
-    });
-
-    let responseBlockId = '';
-
-    for await (const chunk of answerStream) {
-      if (!responseBlockId) {
-        const block: TextBlock = {
-          id: crypto.randomUUID(),
-          type: 'text',
-          data: chunk.contentChunk,
-        };
-
-        session.emitBlock(block);
-
-        responseBlockId = block.id;
-      } else {
-        const block = session.getBlock(responseBlockId) as TextBlock | null;
-
-        if (!block) {
-          continue;
-        }
-
-        block.data += chunk.contentChunk;
-
-        session.updateBlock(block.id, [
-          {
-            op: 'replace',
-            path: '/data',
-            value: block.data,
-          },
-        ]);
+      try {
+        await db
+          .update(messages)
+          .set({
+            status: 'error',
+            responseBlocks: session.getAllBlocks(),
+          })
+          .where(
+            and(
+              eq(messages.chatId, input.chatId),
+              eq(messages.messageId, input.messageId),
+            ),
+          )
+          .execute();
+      } catch (dbError) {
+        console.error('Failed to persist errored search state:', dbError);
       }
     }
-
-    session.emit('end', {});
-
-    await db
-      .update(messages)
-      .set({
-        status: 'completed',
-        responseBlocks: session.getAllBlocks(),
-      })
-      .where(
-        and(
-          eq(messages.chatId, input.chatId),
-          eq(messages.messageId, input.messageId),
-        ),
-      )
-      .execute();
   }
 }
 


### PR DESCRIPTION
## Summary
- catch unhandled search pipeline failures inside both search agents
- emit a session `error` event instead of leaving the client stuck on "Brainstorming"
- persist chat-message searches as `status: error` when they fail mid-flight so the UI can recover cleanly

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`

Fixes #965.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented “Brainstorming” hangs by catching search pipeline errors and surfacing them to the client. Failures now emit a session `error` and are saved as `status: 'error'` so the UI can recover and allow retry. Fixes #965.

- **Bug Fixes**
  - Wrapped both `APISearchAgent` and `SearchAgent` flows in try/catch; failures trigger `session.emit('error', { data: message })` instead of hanging.
  - Persist failed searches with `status: 'error'` and current `responseBlocks`; successful runs still save as `completed`.
  - Hardened widget execution to fail soft and return empty output rather than breaking the search pipeline.

<sup>Written for commit 38300c86bfc4a6226d2dde5d94cedb5616b0bc29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

