### PR TITLE
fix: add forwarded IP headers to searxng requests

### DIFF
--- a/src/lib/searxng.ts
+++ b/src/lib/searxng.ts
@@ -44,6 +44,13 @@ export const searchSearxng = async (
   try {
     const res = await fetch(url, {
       signal: controller.signal,
+      headers: {
+        // SearXNG's default botdetection rejects requests that do not identify
+        // an origin IP. Server-side searches from Vane do not have a browser
+        // proxy adding these headers, so provide a loopback address explicitly.
+        'X-Forwarded-For': '127.0.0.1',
+        'X-Real-IP': '127.0.0.1',
+      },
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- add explicit `X-Forwarded-For` and `X-Real-IP` headers to SearXNG requests
- use loopback headers for Vane's server-side fetches so default SearXNG botdetection no longer aborts the request

## Testing
- `./node_modules/.bin/eslint --config .eslintrc.json src/lib/searxng.ts`
- `./node_modules/.bin/tsc --noEmit`

Closes #858.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add loopback IP headers to `SearXNG` requests so server-side searches no longer fail due to bot detection. Closes #858 by sending X-Forwarded-For and X-Real-IP set to 127.0.0.1.

<sup>Written for commit b39461fe2ca7b742af8b1adc1a1fb85857d42e96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

