### PR TITLE
fix: guard against non-array searching queries in research steps

### DIFF
--- a/src/components/AssistantSteps.tsx
+++ b/src/components/AssistantSteps.tsx
@@ -37,7 +37,8 @@ const getStepTitle = (
   if (step.type === 'reasoning') {
     return isStreaming && !step.reasoning ? 'Thinking...' : 'Thinking';
   } else if (step.type === 'searching') {
-    return `Searching ${step.searching.length} ${step.searching.length === 1 ? 'query' : 'queries'}`;
+    const queries = Array.isArray(step.searching) ? step.searching : [];
+    return `Searching ${queries.length} ${queries.length === 1 ? 'query' : 'queries'}`;
   } else if (step.type === 'search_results') {
     return `Found ${step.reading.length} ${step.reading.length === 1 ? 'result' : 'results'}`;
   } else if (step.type === 'reading') {
@@ -160,6 +161,7 @@ const AssistantSteps = ({
                       )}
 
                       {step.type === 'searching' &&
+                        Array.isArray(step.searching) &&
                         step.searching.length > 0 && (
                           <div className="flex flex-wrap gap-1.5 mt-1.5">
                             {step.searching.map((query, idx) => (

--- a/src/lib/agents/search/researcher/actions/academicSearch.ts
+++ b/src/lib/agents/search/researcher/actions/academicSearch.ts
@@ -30,7 +30,7 @@ const academicSearchAction: ResearchAction<typeof schema> = {
     config.classification.classification.skipSearch === false &&
     config.classification.classification.academicSearch === true,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    input.queries = (Array.isArray(input.queries) ? input.queries : [input.queries]).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,

--- a/src/lib/agents/search/researcher/actions/socialSearch.ts
+++ b/src/lib/agents/search/researcher/actions/socialSearch.ts
@@ -30,7 +30,7 @@ const socialSearchAction: ResearchAction<typeof schema> = {
     config.classification.classification.skipSearch === false &&
     config.classification.classification.discussionSearch === true,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    input.queries = (Array.isArray(input.queries) ? input.queries : [input.queries]).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,

--- a/src/lib/agents/search/researcher/actions/webSearch.ts
+++ b/src/lib/agents/search/researcher/actions/webSearch.ts
@@ -85,7 +85,7 @@ const webSearchAction: ResearchAction<typeof actionSchema> = {
     config.sources.includes('web') &&
     config.classification.classification.skipSearch === false,
   execute: async (input, additionalConfig) => {
-    input.queries = input.queries.slice(0, 3);
+    input.queries = (Array.isArray(input.queries) ? input.queries : [input.queries]).slice(0, 3);
 
     const researchBlock = additionalConfig.session.getBlock(
       additionalConfig.researchBlockId,


### PR DESCRIPTION
## Bug
https://github.com/ItzCrazyKns/Vane/issues/1075 — Client crashes with `t.searching.map is not a function` during web search, causing an application error page.

## Root Cause
The search action handlers (web, academic, social) pass `input.queries` directly to the `searching` field in research substeps. The Zod schema defines `queries` as `z.array(z.string())`, but some LLM providers occasionally return a single string instead of an array for tool call arguments during streaming. When this happens:

1. `input.queries.slice(0, 3)` returns a string (first 3 characters) instead of an array
2. The `searching` property in the substep becomes a string
3. The renderer calls `.map()` on that string, which throws `TypeError: t.searching.map is not a function`

## Fix
**Actions (root cause):** Normalize `input.queries` to always be an array before slicing, wrapping non-array values in `[]`. Applied to all three search actions (webSearch, academicSearch, socialSearch).

**Renderer (defense-in-depth):** Added `Array.isArray()` guards in `AssistantSteps.tsx` so the UI gracefully handles malformed substeps instead of crashing.

## Testing
- When `queries` is a normal array: behavior is unchanged (array is passed through)
- When `queries` is a single string: wrapped into `[string]`, search works correctly
- Renderer: non-array `searching` values render as empty step instead of crashing

Happy to address any feedback.

Greetings, saschabuehrle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes in research steps by normalizing search queries to arrays and guarding the UI against non-array values. Fixes the “t.searching.map is not a function” error seen during web, academic, and social searches.

- **Bug Fixes**
  - Normalize `input.queries` to an array before slicing in `webSearch`, `academicSearch`, and `socialSearch`.
  - Add `Array.isArray()` checks in `AssistantSteps.tsx` for the searching title and chips to avoid calling `.map()` on non-arrays.

<sup>Written for commit 21bd88787e9ea88a79e9fa424c831e342e401526. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

