### PR TITLE
fix: add missing break statements in weather code switch

### DIFF
--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -62,57 +62,79 @@ export const POST = async (req: Request) => {
         break;
 
       case 1:
+        weather.icon = `cloudy-1-${dayOrNight}`;
         weather.condition = 'Mainly Clear';
+        break;
       case 2:
+        weather.icon = `cloudy-1-${dayOrNight}`;
         weather.condition = 'Partly Cloudy';
+        break;
       case 3:
         weather.icon = `cloudy-1-${dayOrNight}`;
         weather.condition = 'Cloudy';
         break;
 
       case 45:
+        weather.icon = `fog-${dayOrNight}`;
         weather.condition = 'Fog';
+        break;
       case 48:
         weather.icon = `fog-${dayOrNight}`;
         weather.condition = 'Fog';
         break;
 
       case 51:
+        weather.icon = `rainy-1-${dayOrNight}`;
         weather.condition = 'Light Drizzle';
+        break;
       case 53:
+        weather.icon = `rainy-1-${dayOrNight}`;
         weather.condition = 'Moderate Drizzle';
+        break;
       case 55:
         weather.icon = `rainy-1-${dayOrNight}`;
         weather.condition = 'Dense Drizzle';
         break;
 
       case 56:
+        weather.icon = `frost-${dayOrNight}`;
         weather.condition = 'Light Freezing Drizzle';
+        break;
       case 57:
         weather.icon = `frost-${dayOrNight}`;
         weather.condition = 'Dense Freezing Drizzle';
         break;
 
       case 61:
+        weather.icon = `rainy-2-${dayOrNight}`;
         weather.condition = 'Slight Rain';
+        break;
       case 63:
+        weather.icon = `rainy-2-${dayOrNight}`;
         weather.condition = 'Moderate Rain';
+        break;
       case 65:
         weather.condition = 'Heavy Rain';
         weather.icon = `rainy-2-${dayOrNight}`;
         break;
 
       case 66:
+        weather.icon = 'rain-and-sleet-mix';
         weather.condition = 'Light Freezing Rain';
+        break;
       case 67:
         weather.condition = 'Heavy Freezing Rain';
         weather.icon = 'rain-and-sleet-mix';
         break;
 
       case 71:
+        weather.icon = `snowy-2-${dayOrNight}`;
         weather.condition = 'Slight Snow Fall';
+        break;
       case 73:
+        weather.icon = `snowy-2-${dayOrNight}`;
         weather.condition = 'Moderate Snow Fall';
+        break;
       case 75:
         weather.condition = 'Heavy Snow Fall';
         weather.icon = `snowy-2-${dayOrNight}`;
@@ -124,18 +146,26 @@ export const POST = async (req: Request) => {
         break;
 
       case 80:
+        weather.icon = `rainy-3-${dayOrNight}`;
         weather.condition = 'Slight Rain Showers';
+        break;
       case 81:
+        weather.icon = `rainy-3-${dayOrNight}`;
         weather.condition = 'Moderate Rain Showers';
+        break;
       case 82:
         weather.condition = 'Heavy Rain Showers';
         weather.icon = `rainy-3-${dayOrNight}`;
         break;
 
       case 85:
+        weather.icon = `snowy-3-${dayOrNight}`;
         weather.condition = 'Slight Snow Showers';
+        break;
       case 86:
+        weather.icon = `snowy-3-${dayOrNight}`;
         weather.condition = 'Moderate Snow Showers';
+        break;
       case 87:
         weather.condition = 'Heavy Snow Showers';
         weather.icon = `snowy-3-${dayOrNight}`;
@@ -147,7 +177,9 @@ export const POST = async (req: Request) => {
         break;
 
       case 96:
+        weather.icon = 'severe-thunderstorm';
         weather.condition = 'Thunderstorm with Slight Hail';
+        break;
       case 99:
         weather.condition = 'Thunderstorm with Heavy Hail';
         weather.icon = 'severe-thunderstorm';


### PR DESCRIPTION
The weather API route has switch fall-through bugs — 15 out of 25 WMO weather codes display the wrong condition text in the widget.

Each group of related codes (e.g. 61 Slight Rain, 63 Moderate Rain, 65 Heavy Rain) was meant to share an icon while showing a distinct condition label, but missing `break` statements cause every early case to fall through to the last one in the group. The condition text gets overwritten on each fall-through, so only the final label survives.

**Before (code 1, "Mainly Clear"):**
- Falls through case 1 → 2 → 3
- Widget shows: condition = "Cloudy", icon = cloudy

**After (code 1):**
- Breaks at case 1
- Widget shows: condition = "Mainly Clear", icon = cloudy

All 10 affected groups have the same pattern. The fix adds a `break` and the group's shared icon to each early case.

Affected WMO codes: 1, 2, 45, 51, 53, 56, 61, 63, 66, 71, 73, 80, 81, 85, 86, 96.

Relates to #970.

**Note:** #922 partially addresses this by adding `break` statements, but leaves the early cases without icon assignments — those cases would render with an empty icon string. This PR adds both the `break` and the icon for each case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes switch fall-through in the weather API so each WMO code shows the correct condition and icon. Adds missing break statements and assigns the shared icon to early cases in each group.

- **Bug Fixes**
  - Added break to early cases in each WMO code group to stop label overwrites; impacts 16 codes across 10 groups.
  - Assigned each group's icon to those cases so every code renders the correct label and icon; addresses Linear #970 and completes gaps left by #922.

<sup>Written for commit e0aac65e6477168101a3f9b6ddedfbe03d4f38ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

