### PR TITLE
fix: add error handling to APISearchAgent to prevent hanging requests

### DIFF
--- a/src/lib/agents/search/api.ts
+++ b/src/lib/agents/search/api.ts
@@ -7,6 +7,7 @@ import { WidgetExecutor } from './widgets';
 
 class APISearchAgent {
   async searchAsync(session: SessionManager, input: SearchAgentInput) {
+    try {
     const classification = await classify({
       chatHistory: input.chatHistory,
       enabledSources: input.config.sources,
@@ -96,6 +97,13 @@ class APISearchAgent {
     }
 
     session.emit('end', {});
+    } catch (err) {
+      console.error('API search agent error:', err);
+
+      session.emit('error', {
+        data: err instanceof Error ? err.message : 'An error occurred during search',
+      });
+    }
   }
 }
 

--- a/src/lib/agents/search/index.ts
+++ b/src/lib/agents/search/index.ts
@@ -11,6 +11,7 @@ import { TextBlock } from '@/lib/types';
 
 class SearchAgent {
   async searchAsync(session: SessionManager, input: SearchAgentInput) {
+    try {
     const exists = await db.query.messages.findFirst({
       where: and(
         eq(messages.chatId, input.chatId),
@@ -180,6 +181,24 @@ class SearchAgent {
         ),
       )
       .execute();
+    } catch (err) {
+      console.error('Search agent error:', err);
+
+      session.emit('error', {
+        data: err instanceof Error ? err.message : 'An error occurred during search',
+      });
+
+      await db
+        .update(messages)
+        .set({ status: 'error' })
+        .where(
+          and(
+            eq(messages.chatId, input.chatId),
+            eq(messages.messageId, input.messageId),
+          ),
+        )
+        .execute();
+    }
   }
 }
 

--- a/src/lib/hooks/useChat.tsx
+++ b/src/lib/hooks/useChat.tsx
@@ -425,6 +425,20 @@ export const ChatProvider = ({ children }: { children: React.ReactNode }) => {
           method: 'POST',
         });
 
+        if (!res.ok) {
+          // Session no longer exists (e.g. server restarted) - mark message as error
+          setLoading(false);
+          isReconnectingRef.current = false;
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.messageId === lastMsg.messageId
+                ? { ...msg, status: 'error' as const }
+                : msg,
+            ),
+          );
+          return;
+        }
+
         if (!res.body) throw new Error('No response body');
 
         const reader = res.body?.getReader();


### PR DESCRIPTION
Fixes #1080

## Problem
`APISearchAgent.searchAsync` had no try-catch block. When any error occurs during search (e.g., model provider failures, classification errors), no `end` or `error` event is emitted to the session. The `/api/search` route creates a Promise that waits for these events — when none arrive, the API request hangs indefinitely, returning no response to the client.

This results in unhandled rejections logged as:
```
⨯ unhandledRejection: Error: <message>
```

## Solution
Wrap `searchAsync` in try-catch and emit an `error` event on failure, matching the existing pattern in `SearchAgent` (the chat UI agent) which already handles errors this way.

## Testing
- Trigger an error in the search pipeline (e.g., use a misconfigured provider) via the `/api/search` endpoint
- Before fix: request hangs with no response
- After fix: request returns a 500 error response with the error message

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add error handling to both search agents and the reconnect flow to prevent hanging requests and stuck messages. Errors now emit proper events, update message status to `error`, and return a 500 instead of hanging.

- **Bug Fixes**
  - Wrap `APISearchAgent.searchAsync` in try/catch and emit a session `error` to prevent `/api/search` from hanging.
  - Wrap `SearchAgent.searchAsync` in try/catch; emit `error` and set the message’s DB status to `error`.
  - In `useChat` reconnect, check `res.ok`; on missing session (e.g., 404), stop loading and mark the last message as `error`.

<sup>Written for commit 6ccc07f40d87cdc94f3ff4980cafb7ab26f344c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

