### PR TITLE
fix: emit error event on SearchAgent failure to prevent stuck brainstorming state

### DIFF
--- a/src/lib/agents/search/index.ts
+++ b/src/lib/agents/search/index.ts
@@ -12,6 +12,20 @@ import { getTokenCount } from '@/lib/utils/splitText';
 
 class SearchAgent {
   async searchAsync(session: SessionManager, input: SearchAgentInput) {
+    try {
+      await this._searchAsync(session, input);
+    } catch (err) {
+      console.error('SearchAgent error:', err);
+      session.emit('error', {
+        data:
+          err instanceof Error
+            ? err.message
+            : 'An unknown error occurred during search',
+      });
+    }
+  }
+
+  private async _searchAsync(session: SessionManager, input: SearchAgentInput) {
     const exists = await db.query.messages.findFirst({
       where: and(
         eq(messages.chatId, input.chatId),


### PR DESCRIPTION
Fixes #1069

## Problem

When any async operation inside `SearchAgent.searchAsync()` fails (e.g. an LLM API call returns an error, a provider does not support structured outputs, or a network timeout occurs), the exception propagates as an unhandled promise rejection.

The route handler calls `agent.searchAsync(session, ...)` **without `await`**, so the error is never caught at the call site. As a result, the session never emits an `'end'` or `'error'` event, leaving the SSE stream open indefinitely. The UI shows the \"Brainstorming\" spinner forever with no way to recover — the user has to reload the page.

This root cause explains multiple open reports of models getting stuck during brainstorming (#1069, #1061, #1006 etc.) whenever the underlying LLM call fails.

## Solution

Extract the original body of `searchAsync` into a private `_searchAsync` method and wrap the call in a `try/catch`. On error, emit the `'error'` event on the session so:

1. The route handler closes the SSE writer and removes listeners.
2. The frontend receives `{ type: 'error', data: message }`, shows a toast, and marks the message as failed.

```ts
async searchAsync(session, input) {
  try {
    await this._searchAsync(session, input);
  } catch (err) {
    console.error('SearchAgent error:', err);
    session.emit('error', {
      data: err instanceof Error ? err.message : 'An unknown error occurred during search',
    });
  }
}
```

## Testing

- Trigger a search with a provider that returns an API error (e.g. invalid API key, rate limit, or a model that rejects the structured-output `response_format`).
- **Before**: UI hangs on \"Brainstorming\" indefinitely.
- **After**: UI shows an error toast and the message is marked as failed, allowing the user to retry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit an `error` event when a `SearchAgent` search fails so the SSE stream closes and the UI doesn’t get stuck on “Brainstorming”. Fixes #1069.

- **Bug Fixes**
  - Moved core logic to a private `_searchAsync` and wrapped `searchAsync` in try/catch; on failure, emit `session.error` with the message.
  - Ensures the route handler closes the SSE stream and the frontend shows an error and marks the message as failed, allowing retry.

<sup>Written for commit ad7aa6ec16666c7d0b933273071f7edbd1c9d09a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

