### PR TITLE
Fix typo in transition duration class

### DIFF
--- a/src/components/DeleteChat.tsx
+++ b/src/components/DeleteChat.tsx
@@ -107,7 +107,7 @@ const DeleteChat = ({
                     </button>
                     <button
                       onClick={handleDelete}
-                      className="text-red-400 text-sm hover:text-red-500 transition duration200"
+                      className="text-red-400 text-sm hover:text-red-500 transition duration-200"
                     >
                       Delete
                     </button>


### PR DESCRIPTION
 Typo: duration200 missing hyphen → should be duration-200

sorry again very useless pr i noticed this when i was creating deleteAllChats feature by accident. i thought it would create a unnecessary bug.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in the Tailwind transition duration class on the Delete button in `DeleteChat.tsx`. Replaces `duration200` with `duration-200` so the hover transition runs as expected.

<sup>Written for commit 6196ab206da2bb37cc27d4f51f52fae7d4b5a375. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

