### PR TITLE
fix: deduplicate search sources by title to prevent duplicate citations

### DIFF
--- a/src/lib/agents/search/researcher/index.ts
+++ b/src/lib/agents/search/researcher/index.ts
@@ -187,10 +187,22 @@ class Researcher {
       .flatMap((a) => a.results);
 
     const seenUrls = new Map<string, number>();
+    const seenTitles = new Set<string>();
 
     const filteredSearchResults = searchResults
       .map((result, index) => {
         if (result.metadata.url && !seenUrls.has(result.metadata.url)) {
+          // Deduplicate by normalized title to avoid citing the same paper
+          // from multiple academic platforms (e.g. PubMed, ScienceDirect,
+          // ResearchGate, Google Scholar) as separate sources.
+          if (result.metadata.title) {
+            const normalizedTitle = result.metadata.title.toLowerCase().trim();
+            if (seenTitles.has(normalizedTitle)) {
+              return undefined;
+            }
+            seenTitles.add(normalizedTitle);
+          }
+
           seenUrls.set(result.metadata.url, index);
           return result;
         } else if (result.metadata.url && seenUrls.has(result.metadata.url)) {


### PR DESCRIPTION
Fixes #1109

## Problem

When using balanced or quality search modes, the same academic paper often appears across multiple platforms (PubMed, ScienceDirect, ResearchGate, Google Scholar) with different URLs. The existing URL-based deduplication (`seenUrls`) did not catch these cross-platform duplicates, so the writer LLM received the same paper indexed as 4 separate sources and cited all of them — leading to reports with 100+ citations where the majority were duplicates of the same underlying paper.

## Solution

Add a normalised-title `Set` (`seenTitles`) alongside the existing URL `Map` in `Researcher.research()`. Before adding a new result to the final source list, its title is lower-cased and trimmed; if that normalised title has already been seen, the result is dropped. The first (highest-priority) occurrence is kept; subsequent cross-platform duplicates are silently discarded.

- Results without a `metadata.title` are unaffected by the new check.
- The existing URL-based merge logic (appending content of same-URL duplicates) is unchanged.

## Testing

Manually traced through the deduplication logic with a hypothetical set of results for the same paper appearing on PubMed, ScienceDirect, ResearchGate, and Google Scholar — only the first result is retained, the rest are filtered out before being numbered and passed to the writer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicate search results by normalized title across platforms to prevent duplicate citations in balanced/quality modes. Keeps the first occurrence and fixes #1109.

- **Bug Fixes**
  - Added a `seenTitles` Set (lowercased, trimmed) in `Researcher.research()` to drop cross-platform duplicates before numbering.
  - Kept existing URL-merge behavior; results without `metadata.title` are unchanged.

<sup>Written for commit 7ea7c2ae08fb9a06f819fe6d39e0075720e4ff05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

