### PR TITLE
fix: remove redundant type field from web_search tool schema

### DIFF
--- a/src/lib/agents/search/researcher/actions/search/webSearch.ts
+++ b/src/lib/agents/search/researcher/actions/search/webSearch.ts
@@ -4,7 +4,6 @@ import { ResearchBlock } from '@/lib/types';
 import { executeSearch } from './baseSearch';
 
 const actionSchema = z.object({
-  type: z.literal('web_search'),
   queries: z
     .array(z.string())
     .describe('An array of search queries to perform web searches for.'),


### PR DESCRIPTION
Fixes #1010

## Problem

The `web_search` action schema included a redundant `type: z.literal('web_search')` field. When this schema is serialised to JSON Schema (via `z.toJSONSchema`), the resulting object requires the LLM to include `{"type": "web_search", "queries": [...]}` in its tool call arguments — even though the function name already identifies which tool is being called.

Some Ollama-hosted models that support tool use (e.g. LFM2) do not include this superfluous `type` field in their generated tool call arguments. When Ollama validates the arguments against the schema, the call fails silently. The researcher loop then sees zero tool calls after the first iteration, breaks immediately, and the writer generates a response with no search context. This explains the symptoms reported in #1010:

- Brainstorming section never resolves
- No sources listed
- No research progress shown
- No citation numbers in the answer

The same underlying schema issue was also identified for Groq providers (#980).

## Solution

Remove the `type: z.literal('web_search')` field from `actionSchema`. The `execute` handler never reads `input.type` — it only accesses `input.queries` — so this is a safe, non-breaking change. The resulting schema is simpler and compatible with a wider range of models.

## Testing

- TypeScript compilation passes (`npx tsc --noEmit`)
- Models that previously skipped tool calling due to schema validation (e.g. LFM2 via Ollama) should now correctly issue `web_search` tool calls and receive proper search results

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the redundant type field from the `web_search` action schema to stop tool-call validation failures with some models. This restores researcher tool calls so brainstorming completes and sources/citations appear.

- Bug Fixes
  - Removed `type: z.literal('web_search')` from `actionSchema`; schema now only requires `queries`.
  - Avoids silent JSON Schema validation failures in models that omit the extra field (e.g., LFM2 via Ollama, Groq providers).

<sup>Written for commit e6ee0e635ac03fa2572a00d1e466df19a5dc9c6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

